### PR TITLE
Add note about using id as sort when looking to sort by date created

### DIFF
--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -456,7 +456,7 @@ paths:
             - desc
         - name: sort
           description: |
-            Field name to sort by.
+            Field name to sort by. Note: Since `id` increments when new products are added, you can use that field to sort by product create date.
           required: false
           in: query
           type: string


### PR DESCRIPTION
Add note about using id as sort when looking to sort by date created.

This is based on feedback from Vercel. They wanted to sort on date_created to return the newest products in the catalog first, before we realized that id could be used to achieve the same result.