### PR TITLE
DEVDOCS-2308: Remove primary_image from Write Product Reqs

### DIFF
--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -20176,7 +20176,7 @@ definitions:
           variants:
             $ref: '#/definitions/productVariant_Post_Product'
     description: The model for a POST to create a product.
-    title: ''
+    title: product_Post
   product_Put:
     description: The model for a PUT to update a product.
     allOf:


### PR DESCRIPTION
Removed 'primary_image' object from POST and PUT requests.