### PR TITLE
Remove status field from storefront settings

### DIFF
--- a/reference/settings.v3.yml
+++ b/reference/settings.v3.yml
@@ -522,13 +522,6 @@ components:
       title: ''
       type: object
       properties:
-        status:
-          type: string
-          example: prelaunch
-          enum:
-            - live
-            - prelaunch
-            - maintenance
         down_for_maintenance_message:
           type: string
         prelaunch_message:


### PR DESCRIPTION
This setting will no longer be added to the API under this endpoint. Instead, channel status will be used. So, removing from the spec!