### PR TITLE
Added next as storefront platform option

### DIFF
--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -51,6 +51,7 @@ info:
     | `acquia`          | `storefront`              |
     | `bloomreach`      | `storefront`              |
     | `deity`           | `storefront`              |
+    | `next`            | `storefront`              |
     | `google_shopping` | `marketing`               |
     | `custom`          | `storefront`, `pos`, `marketing`, `marketplace` |
 
@@ -1272,20 +1273,21 @@ definitions:
     type: string
     description: 'The name of the platform for the channel; channel `platform` and `type` must be a [valid combination](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api#platform).'
     enum:
-      - wordpress
-      - square
-      - drupal
+      - bigcommerce
       - acquia
       - bloomreach
       - deity
+      - drupal
+      - next
+      - wordpress
       - amazon
-      - facebook
       - ebay
+      - facebook
       - google_shopping
-      - vend
       - clover
+      - square
+      - vend
       - custom
-      - bigcommerce
     title: channelPlatform
   channel_currencies:
     description: ''


### PR DESCRIPTION
Adding here for consistency as this enum is already being used in prod. We're rolling out support for Next.js via a Vercel built storefront starter this week.