### PR TITLE
DEVDOCS-2407-add-date-option-create-carts.v3.yml

### DIFF
--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -81,6 +81,22 @@ paths:
                       }
                   ]
               }
+           Create a Cart using date option: |-
+            {
+              "line_items": [
+                {
+                  "quantity": 5,
+                  "product_id": 191,
+                  "variant_id": 185,
+                  "option_selections": [
+                    {
+                      "option_id": 440,
+                      "option_value": 1743570000
+                    }
+                  ]
+                }
+              ]
+            }   
             With a Variant of Checkbox and Picklist: |-
               {
                 "line_items": [


### PR DESCRIPTION
DEVDOCS-2407 indicates that documentation is missing for the case of creating a cart using the date option. I added in an additional example so users would know how to do this. 