### PR TITLE
Fix image manager widget type

### DIFF
--- a/models/theme_objects.yml
+++ b/models/theme_objects.yml
@@ -4278,11 +4278,13 @@ definitions:
   widget_image_manager:
     type: object
     title: image_manager
+    required:
+      - default
     properties:
       type:
         type: string
         description: The type of setting component to display.
-        example: '"imageMaker"'
+        example: '"imageManager"'
       id:
         type: string
         description: >-


### PR DESCRIPTION
This lost me about an hour of my day. The example had the type as "imageMaker" instead of the correct "imageManager". Also, seemingly, "default' is a required property but wasn't indicated as such.