### PR TITLE
Fix Incorrect Float Type in Orders V2

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -2732,8 +2732,8 @@ components:
                 type:
                  - string
                  - integer
-                 - float
-                format: number
+                 - number
+                format: float
               wrapping_cost_ex_tax:
                 description: The value of the wrapping cost, excluding tax. (Float,
                   Float-As-String, Integer)
@@ -3121,9 +3121,9 @@ components:
           example: 5.0000
           type:
             - string
-            - float
+            - number
             - integer
-          format: number
+          format: float
         type:
           type:
             - integer


### PR DESCRIPTION
I was trying to run the Orders V2 schema through [`dtsgenerator`](https://github.com/horiuchi/dtsgenerator) and got the following error:

```
Error: unknown type: float
```

After closer inspection, I think you may have switched the `number` and `float` `type` and `format` respectively.

See [here](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#dataTypes) for the Open API spec. `float` is not a type.

This fixes the error and allows `dtsgenerator` to work.

---

Hope this helps! I tried to follow PR conventions as much as I could.