### PR TITLE
Add OAS Linting Exceptions

### DIFF
--- a/reference/.spectral.yml
+++ b/reference/.spectral.yml
@@ -1,3 +1,170 @@
 extends: [[spectral:oas]]
 rules:
   info-contact: off
+  oas2-unused-definition: off
+  oas3-unused-components-schema: off
+
+except:
+  # perm exceptions for host property
+  "carts.sf.yml#/host":
+    - oas2-schema
+  "checkouts.sf.yml#/host":
+    - oas2-schema
+  "form_fields.sf.yml#/host":
+    - oas2-schema
+  "orders.sf.yml#/host":
+    - oas2-schema
+  "subscriptions.sf.yml#/host":
+    - oas2-schema
+  "current_customer.yml#/host":
+    - oas2-schema
+  "customer_login.yml#/host":
+    - oas2-schema
+  "shipping_provider.yml#/host":
+    - oas2-schema
+
+  # temp until existing fixed
+  "carts.sf.yml":
+    - invalid-ref
+    - oas2-valid-definition-example
+    - operation-tag-defined
+    - openapi-tags
+  "carts.v3.yml":
+    - oas2-oneOf
+    - oas2-valid-definition-example
+    - oas2-valid-response-schema-example
+    - operation-tag-defined
+  "catalog.v3.yml":
+    - oas2-operation-security-defined
+    - oas3-schema
+    - oas2-schema
+    - oas2-valid-definition-example
+    - oas2-valid-response-schema-example
+    - oas2-valid-response-example
+    - oas2-valid-parameter-example
+  "channels.v3.yml":
+    - operation-operationId
+    - oas3-schema
+    - oas3-valid-oas-content-example
+  "checkouts.sf.yml":
+    - oas2-valid-response-example
+  "checkouts.v3.yml":
+    - no-$ref-siblings
+    - oas2-schema
+    - oas2-operation-security-defined
+    - operation-parameters
+  "currencies.v2.yml":
+    - oas2-valid-definition-example
+    - oas2-valid-parameter-example
+    - oas2-valid-response-schema-example
+    - operation-operationId
+    - no-$ref-siblings
+  "current_customer.yml":
+    - operation-2xx-response
+  "custom-template-associations.v3.yml":
+    - openapi-tags
+    - operation-tag-defined
+  "customer_login.yml":
+    - operation-operationId
+    - operation-2xx-response
+  "customers.v2.yml":
+    - oas2-valid-response-schema-example
+    - oas2-valid-parameter-example
+    - oas2-valid-response-example
+    - oas2-valid-definition-example
+  # "customers.v3.yml":
+  "email_templates.v3.yml":
+    - oas3-schema
+    - operation-tag-defined
+    - openapi-tags
+  "form_fields.sf.yml":
+    - operation-operationId
+  "geography.v2.yml":
+    - operation-operationId
+    - oas2-valid-response-example
+  "marketing.v2.yml":
+    - oas2-valid-definition-example
+    - oas2-valid-parameter-example
+    - oas2-valid-response-example
+    - oas2-valid-response-schema-example
+    - operation-operationId
+  "orders.sf.yml":
+    - operation-tag-defined
+    - oas3-valid-schema-example
+  "orders.v2.oas2.yml":
+    - oas3-valid-schema-example
+    - oas3-valid-oas-content-example
+    - oas3-schema
+  "orders.v3.yml":
+    - oas2-valid-definition-example
+    - oas2-valid-parameter-example
+    - oas2-valid-response-example
+    - oas2-anyOf
+  "payment_methods.v2.yml":
+    - operation-operationId
+  # "payment_processing.yml":
+  "price_lists.v3.yml":
+    - oas2-schema
+    - oas2-valid-response-example
+  "pricing.sf.yml":
+    - oas2-valid-response-example
+    - oas2-schema
+    - no-$ref-siblings
+  "redirects.v3.yml":
+    - oas2-valid-response-example
+    - oas2-schema
+    - no-$ref-siblings
+  # "scripts.v3.yml":
+  "settings.v3.yml":
+    - oas3-valid-oas-content-example
+    - operation-operationId
+  # "shipping_provider.yml":
+  "shipping.v2.yml":
+    - oas2-valid-response-schema-example
+    - oas2-valid-parameter-example
+    - oas2-valid-response-example
+    - oas2-valid-definition-example
+    - typed-enum
+    - operation-operationId
+  "shipping.v3.yml":
+    - oas2-valid-definition-example
+    - operation-operationId
+    - typed-enum
+  "sites.v3.yml":
+    - oas2-valid-response-example
+    - operation-operationId
+  "store_content.v2.yml":
+    - oas2-valid-response-example
+    - oas2-valid-definition-example
+    - oas2-valid-parameter-example
+    - oas2-valid-response-schema-example
+  "store_information.v2.yml":
+    - oas2-valid-definition-example
+    - oas2-valid-response-example
+    - operation-operationId
+    - oas2-valid-response-schema-example
+  "storefront_tokens.v3.yml":
+    - oas2-valid-definition-example
+    - oas2-valid-parameter-example
+  # "subscribers.v3.yml":
+  "subscriptions.sf.yml":
+    - operation-operationId
+  "tax_classes.v2.yml":
+    - oas2-valid-definition-example
+    - oas2-valid-response-example
+    - oas2-valid-response-schema-example
+  "themes.v3.yml":
+    - oas3-schema
+    - operation-operationId
+  # "webhooks.v2.yml":
+  "webhooks.v3.yml":
+    - oas3-valid-oas-content-example
+  "widgets.v3.yml":
+    - typed-enum
+    - oas2-anyOf
+    - oas2-valid-response-example
+  "wishlists.v3.yml":
+    - oas2-valid-definition-example
+    - oas2-valid-response-example
+    - oas2-valid-response-schema-example
+


### PR DESCRIPTION
* Added permanent exceptions for `host:` property in files where the host is not a bigcommerce server.
* Added temporary exceptions for all files with existing errors

This will allow us to use stoplight's spectral github action check pull requests for errors, but make exceptions for existing errors that might not have been a part of the pull request. 