### PR TITLE
feat(orders): ORDERS-3998 add coupon code validation so only white listed values are allowed

### DIFF
--- a/reference/marketing.v2.yml
+++ b/reference/marketing.v2.yml
@@ -934,8 +934,9 @@ definitions:
         type: boolean
       code:
         type: string
-        description: The coupon code that customers will use to receive their discounts. Value must be unique.
+        description: The coupon code that customers will use to receive their discounts. Value must be unique. Only alphanumeric values, white space, underscore and hypen are allowed.
         example: S2549JM0Y
+        pattern: '[a-zA-Z0-9_\ -]'
       applies_to:
         type: object
         description: 'If it is not included in the PUT request, its existing value on the coupon will be cleared. Also required to be set on the POST request'


### PR DESCRIPTION
As part of security fix to prevent XSS using coupon code, we need to add white list validation on the coupon code input. (see https://jira.bigcommerce.com/browse/ORDERS-3972 for details)

Given this change may come as a potential breaking change (we might have api users that use other special characters that are outside the whitelist), I would really appreciate guidance from the dev-doc team what's the best way to give our api users notification about this change.

cc @bigcommerce/dev-docs 