### PR TITLE
DEVDOCS-2612 remove unnecessary fields from POST / PUT order shipment request bodies

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -603,7 +603,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/orderShipment_Post_Request'
+              $ref: '#/components/schemas/orderShipment_Post'
         required: true
         x-examples:
           application/json:
@@ -676,7 +676,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/orderShipment_Post_Response'
+              $ref: '#/components/schemas/orderShipment_Put'
         required: true
         x-examples:
           application/json:
@@ -3763,9 +3763,9 @@ components:
         - product_id
         - product_options
         - quantity
-    orderShipment_Post_Request:
+    orderShipment_Post:
       type: object
-      title: orderShipment_Post_Request
+      title: orderShipment_Post
       properties:
         order_address_id:
           description: ID of the desired `shipping_address` associated with the shipment.
@@ -3815,9 +3815,9 @@ components:
               quantity:
                 type: number
                 example: 2
-    orderShipment_Post_Response:
+    orderShipment_Put:
       type: object
-      title: orderShipment_Post_Response
+      title: orderShipment_Put
       properties:
         order_address_id:
           description: ID of the desired `shipping_address` associated with the shipment.
@@ -3855,21 +3855,6 @@ components:
         comments:
           description: Comments the shipper wishes to add.
           type: string
-        items:
-          description: 'The items in the shipment. This object has the following members, all integer: order_product_id (required), quantity (required), product_id (read-only). A sample items value might be: [ {"order_product_id":16,"product_id": 0,"quantity":2} ]'
-          type: array
-          items:
-            type: object
-            properties:
-              order_product_id:
-                type: integer
-                example: 5
-              product_id:
-                type: integer
-                example: 87
-              quantity:
-                type: number
-                example: 2
     orderStatus_Base:
       title: orderStatus_Base
       type: object

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -603,7 +603,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/orderShipment_Post'
+              $ref: '#/components/schemas/orderShipment_Post_Request'
         required: true
         x-examples:
           application/json:
@@ -676,7 +676,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/orderShipment_Post'
+              $ref: '#/components/schemas/orderShipment_Post_Response'
         required: true
         x-examples:
           application/json:
@@ -3763,9 +3763,61 @@ components:
         - product_id
         - product_options
         - quantity
-    orderShipment_Post:
+    orderShipment_Post_Request:
       type: object
-      title: orderShipment_Post
+      title: orderShipment_Post_Request
+      properties:
+        order_address_id:
+          description: ID of the desired `shipping_address` associated with the shipment.
+          example: 20
+          type: integer
+        tracking_number:
+          description: Tracking number of the shipment.
+          example: w4se4b6ASFEW4T
+          type: string
+        shipping_method:
+          description: |
+            Additional information to describe the method of shipment (ex. Standard, Ship by Weight, Custom Shipment). Can be used for live quotes from certain shipping providers.
+            If different from `shipping_provider`, `shipping_method` should correspond to `tracking_carrier`.
+          example: Ship by Weight
+          type: string
+        shipping_provider:
+          type: string
+          description: Enum of the BigCommerce shipping-carrier integration/module.
+          enum:
+            - auspost
+            - canadapost
+            - endicia
+            - usps
+            - fedex
+            - ups
+            - upsready
+            - upsonline
+            - shipperhq
+        tracking_carrier:
+          type: string
+          title: Tracking Carrier
+          description: |-
+            Tracking carrier for the shipment.
+            Acceptable values include an empty string (`""`) or one of the valid tracking-carrier values viewable [here](https://docs.google.com/spreadsheets/d/1w9c_aECSCGyf-oOrvGeUniDl-ARGKemfZl0qSsav8D4/pubhtml?gid=0&single=true) and downloadable as a .CSV file [here](https://docs.google.com/spreadsheets/d/1mTueEynfcEmwsU2y2Jd2MX-8GKwNZrmlRMBcIElg9aY/pub?gid=0&single=true&output=csv).
+        comments:
+          description: Comments the shipper wishes to add.
+          type: string
+        items:
+          description: 'The items in the shipment. This object has the following members, all integer: order_product_id (required), quantity (required), product_id (read-only). A sample items value might be: [ {"order_product_id":16,"product_id": 0,"quantity":2} ]'
+          type: array
+          items:
+            type: object
+            properties:
+              order_product_id:
+                type: integer
+                example: 5
+              quantity:
+                type: number
+                example: 2
+    orderShipment_Post_Response:
+      type: object
+      title: orderShipment_Post_Response
       properties:
         order_address_id:
           description: ID of the desired `shipping_address` associated with the shipment.


### PR DESCRIPTION
## What
**1.** Updated the order shipments documentation POST request example and schema body by removing the **product_id** field.

**2.** Updated the order shipments documentation PUT request example and schema body by removing the **items** object.
## Why
**1.** When **product_id** field is included in the **POST /orders/{order_id}/shipments request**, users receive the following error:
>"status": 400, "message": "The field 'product_id' cannot be written to. Please remove it from your request before trying again."

When **product_id** field is removed from the request body and all the other fields are valid, a successful response is returned.

**2.** When **items** object is included in the **PUT/orders/{order_id}/shipments/{shipment_id}**, users receive the following error:
>"status": 400, "message": "The field 'items' cannot be written to. Please remove it from your request before trying again."

When **items** object is removed from the request body and all the other fields are valid, a successful response is returned.
## Testing/Proof
**1. POST /orders/{order_id}/shipments request**
### Before
<img width="969" alt="Screen Shot 2021-03-11 at 11 40 36" src="https://user-images.githubusercontent.com/80028746/110721593-f72a0a00-8264-11eb-9b34-27ae0b8dd8d9.png">

### After
<img width="969" alt="Screen Shot 2021-03-11 at 11 37 44" src="https://user-images.githubusercontent.com/80028746/110721619-fdb88180-8264-11eb-863e-111efaf9eff3.png">

**2. PUT /orders/{order_id}/shipments/{shipment_id}**
### Before
![image](https://user-images.githubusercontent.com/80028746/110743202-c5786980-828b-11eb-9d0e-2c4561537112.png)

### After
![image](https://user-images.githubusercontent.com/80028746/110743096-9a8e1580-828b-11eb-9bb0-2e31e5e1d5ba.png)

ping @bigcommerce/shipping @bigcommerce/orders @bigcommerce/dev-docs @aglensmith 