### PR TITLE
Specify Spectral 5.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: mkdir ~/junit
       - run:
           name: "API Description Linter"
-          command: npx @stoplight/spectral lint reference/*.yml -f=junit -o ~/junit/test_results.xml -v -F=warn --ruleset=./.spectral.yaml
+          command: npx @stoplight/spectral@5.8.1 lint reference/*.yml -f=junit -o ~/junit/test_results.xml -v -F=warn --ruleset=./.spectral.yaml
       - store_test_results:
           path: ~/junit
       - store_artifacts:


### PR DESCRIPTION
The new version of spectral (5.9.0) seems to be detecting issues (which appear to be false positives) that the previous version dididn't (5.8.1).  Running the following locally I was able to replicate the errors:

```
npx @stoplight/spectral@5.9.0 lint reference/*.yml -f=stylish -F=warn -v --ruleset=./.spectral.yaml
```

Running the previous version shows no errors:

```
npx @stoplight/spectral@5.8.1 lint reference/*.yml -f=stylish -F=warn -v --ruleset=./.spectral.yaml
```

the .circleci/.config.yaml was configured to run `npx @stoplight/spectral` without specifying a version – this results in the latest version being used. Specifying the version in the command to be `5.8.1` should fix and prevent updates to spectral causing build failures in the future. 