### PR TITLE
DEVDOCS-2636-update-AddCartLineItems-description

### DIFF
--- a/reference/carts.sf.yml
+++ b/reference/carts.sf.yml
@@ -66,14 +66,14 @@ paths:
                       productId: 230
                       optionSelections:
                         - optionId: 10
-                          optionValue: "Some Text Value"
+                          optionValue: Some Text Value
                   locale: en
         required: true
       responses:
         '200':
           $ref: '#/components/responses/postCarts'
       x-codegen-request-body-name: cartData
-  /carts/{cartId}:
+  '/carts/{cartId}':
     delete:
       tags:
         - Cart
@@ -104,7 +104,7 @@ paths:
         '204':
           description: ''
           content: {}
-  /carts/{cartId}/items:
+  '/carts/{cartId}/items':
     post:
       tags:
         - Cart Items
@@ -168,7 +168,7 @@ paths:
                         - optionId: 11
                           optionValue: test
         description: ''
-  /carts/{cartId}/items/{itemId}:
+  '/carts/{cartId}/items/{itemId}':
     put:
       tags:
         - Cart Items
@@ -176,7 +176,7 @@ paths:
       description: |-
         Updates a *Cart* line item. Updates an existing, single line item in the cart.
 
-        This endpoint only supports quantity change for simple products. If a modified product or variant needs to be changed or updated, the product will need to be removed and re-added to the cart with the correct variants using the [Add Cart Line Item](https://developer.bigcommerce.com/api-reference/storefront/carts/cart-items/addcartlineitem) endpoint.
+        If a modified product or variant needs to be changed or updated, the product will need to be removed and re-added to the cart with the correct variants using the [Add Cart Line Item](https://developer.bigcommerce.com/api-reference/storefront/carts/cart-items/addcartlineitem) endpoint.
 
         <div class="HubBlock--callout">
         <div class="CalloutBlock--info">


### PR DESCRIPTION
[DEVDOCS-2636](https://jira.bigcommerce.com/browse/DEVDOCS-2636)

This ticket is closed but the developer just confirmed that they in fact could  also update v2 products. Therefore removing the following line "This endpoint only supports quantity change for simple products."  This endpoint works for all products. The rest of the description is correct.