### PR TITLE
add image_url to POST /catalog/products/{product_id}/variants

### DIFF
--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -19336,6 +19336,9 @@ definitions:
             x-nullable: true
             minLength: 0
             maxLength: 255
+          image_url:
+            type: string
+            description: Publicly available image url 
       - properties:
           product_id:
             type: integer


### PR DESCRIPTION
`image_url` present in POST example, but not in schema for creating a product variant. Added `image_url` to schema. 
https://jira.bigcommerce.com/browse/DEVDOCS-2608

