### PR TITLE
Fix invalid examples

### DIFF
--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -369,9 +369,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
-            Invalid Response:
               examples:
-                response:
+                Invalid Response:
+                  summary: "Invalid response example"
                   value:
                     status: 400
                     title: Input is invalid
@@ -405,9 +405,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
-            422 Example:
               examples:
-                response:
+                422 Example:
                   value:
                     status: 422
                     title: JSON data is missing or invalid
@@ -751,9 +750,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/currencyAssignments_Resp'
-            example-1:
               examples:
-                response:
+                example-1:
                   value:
                     data:
                       - channel_id: 123
@@ -783,9 +781,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/currencyAssignments_Resp'
-            example-1:
               examples:
-                response:
+                example-1:
                   value:
                     data:
                       - channel_id: 123
@@ -808,9 +805,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/currencyAssignments_Resp'
-            example-1:
               examples:
-                response:
+                example-1:
                   value:
                     data:
                       - channel_id: 123
@@ -838,9 +834,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/currencyAssignments_Resp'
-            example-1:
               examples:
-                response:
+                example-1:
                   value:
                     data:
                       - channel_id: 123
@@ -1054,9 +1049,7 @@ components:
                 meta:
                   pagination:
                     total: 1
-        with currencies:
-          examples:
-            response:
+            with currencies:
               value:
                 data:
                   - id: 1
@@ -1138,9 +1131,7 @@ components:
                         - title: Settings
                           query_path: settings
                 meta: {}
-        with currencies:
-          examples:
-            response:
+            with currencies:
               value:
                 data:
                   id: 391563
@@ -1908,8 +1899,7 @@ components:
           type: boolean
           description: Indicates whether the variation of the currently active Theme on the Channel has been purchased by the store
         active_theme_partner:
-          type: object
-          properties: '#/components/schemas/Partner'
+          $ref: '#/components/schemas/Partner'
         active_theme_style_editable:
           type: boolean
           description: Indicates whether the currently active Theme on the Channel is editable with the Style Editor
@@ -1935,24 +1925,24 @@ components:
         active_theme_variation_name:
           type: string
           description: The name of the variation of the currently active Theme on the Channel
-      Partner:
-        title: Partner
-        type: object
-        description: Details about the Partner's relationship to Themes
-        nullable: true
-        properties:
-          id:
-            type: string
-            description: The UUID of the partner of a theme
-          name:
-            type: string
-            description: The display name of the partner of a theme
-          contact_url:
-            type: string
-            description: The URL for contact/support of the partner of a theme
-          contact_email:
-            type: string
-            description: The email address for contact/support of the partner of a theme
+    Partner:
+      title: Partner
+      type: object
+      description: Details about the Partner's relationship to Themes
+      nullable: true
+      properties:
+        id:
+          type: string
+          description: The UUID of the partner of a theme
+        name:
+          type: string
+          description: The display name of the partner of a theme
+        contact_url:
+          type: string
+          description: The URL for contact/support of the partner of a theme
+        contact_email:
+          type: string
+          description: The email address for contact/support of the partner of a theme
     Upgrade:
       title: Upgrade
       type: object

--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -460,11 +460,6 @@ paths:
             type: string
             format: date-time
         - $ref: '#/components/parameters/product_id_in'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/listing_Full'
       responses:
         '200':
           $ref: '#/components/responses/listing_Resp_Collection'

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -1855,747 +1855,574 @@ components:
                     date_modified: '2019-02-19T18:34:16Z'
                 meta: {}
             with include:
-              value: |-
-                {
-                    "data": [
-                        {
-                            "id": 11,
-                            "address_count": 8,
-                            "addresses": [
-                                {
-                                    "id": 16,
-                                    "address1": "555 East Street",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Austin",
-                                    "company": "",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 11,
-                                    "first_name": "Jane",
-                                    "last_name": "Doe",
-                                    "phone": "1234567890",
-                                    "postal_code": "78108",
-                                    "state_or_province": "Texas",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": "Leave in backyard"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": 23,
-                                    "address1": "111 E West Street",
-                                    "address2": "654",
-                                    "address_type": "commercial",
-                                    "city": "Akron",
-                                    "company": "BigCommerce",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 11,
-                                    "first_name": "Jane",
-                                    "last_name": "Doe",
-                                    "phone": "1234567890",
-                                    "postal_code": "44325",
-                                    "state_or_province": "Ohio",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": ""
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": 30,
-                                    "address1": "122 First Street",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Austin",
-                                    "company": "",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 11,
-                                    "first_name": "Jon",
-                                    "last_name": "Doe",
-                                    "phone": "6789012345",
-                                    "postal_code": "78726",
-                                    "state_or_province": "Texas",
-                                    "form_fields": []
-                                },
-                                {
-                                    "id": 46,
-                                    "address1": "666 Sussex St",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Anywhere",
-                                    "company": "Acme Pty Ltd",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 11,
-                                    "first_name": "Trishy",
-                                    "last_name": "Test",
-                                    "phone": "",
-                                    "postal_code": "12345",
-                                    "state_or_province": "Some State",
-                                    "form_fields": []
-                                },
-                                {
-                                    "id": 55,
-                                    "address1": "123 Main Street",
-                                    "address2": "",
-                                    "address_type": "commercial",
-                                    "city": "Austin",
-                                    "company": "BigCommerce",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 11,
-                                    "first_name": "Jane",
-                                    "last_name": "Doe",
-                                    "phone": "123-345-7890",
-                                    "postal_code": "78726",
-                                    "state_or_province": "Texas",
-                                    "form_fields": []
-                                },
-                                {
-                                    "id": 56,
-                                    "address1": "2234 Main Street",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Austin",
-                                    "company": "BigCommerce",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 11,
-                                    "first_name": "Jane",
-                                    "last_name": "Doe",
-                                    "phone": "123-345-7890",
-                                    "postal_code": "78726",
-                                    "state_or_province": "Texas",
-                                    "form_fields": []
-                                },
-                                {
-                                    "id": 59,
-                                    "address1": "122 First Street",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Austin",
-                                    "company": "",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 11,
-                                    "first_name": "Jon",
-                                    "last_name": "Doe",
-                                    "phone": "6789012345",
-                                    "postal_code": "78726",
-                                    "state_or_province": "Texas",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": "Leave in backyard"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "attributes": [
-                                {
-                                    "id": 1,
-                                    "customer_id": 11,
-                                    "attribute_id": 1,
-                                    "attribute_value": "52",
-                                    "date_created": "2018-11-14T18:58:08Z",
-                                    "date_modified": "2019-02-19T19:26:21Z"
-                                }
-                            ],
-                            "authentication": {
-                                "force_password_reset": false
-                            },
-                            "company": "",
-                            "customer_group_id": 0,
-                            "email": "janedoe@example.com",
-                            "first_name": "Jane",
-                            "last_name": "Doe",
-                            "notes": "",
-                            "phone": "1234567890",
-                            "registration_ip_address": "",
-                            "tax_exempt_category": "",
-                            "date_created": "2018-09-05T13:43:54Z",
-                            "date_modified": "2019-02-21T18:03:59Z",
-                            "attribute_count": 1,
-                            "form_fields": [
-                                {
-                                    "name": "AccountSignUpField",
-                                    "value": "345678ABC"
-                                }
-                            ],
-                            "accepts_product_review_abandoned_cart_emails": true,
-                            "store_credit_amounts": [
-                                {
-                                    "amount": 0
-                                }
-                            ]
-                        },
-                        {
-                            "id": 14,
-                            "address_count": 1,
-                            "addresses": [
-                                {
-                                    "id": 24,
-                                    "address1": "St Katharine's & Wapping",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "London",
-                                    "company": "",
-                                    "country": "United Kingdom",
-                                    "country_code": "GB",
-                                    "customer_id": 14,
-                                    "first_name": "Nathaniel",
-                                    "last_name": "Hornblower",
-                                    "phone": "5122134567",
-                                    "postal_code": "EC3N 4AB",
-                                    "state_or_province": "UK",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": ""
-                                        }
-                                    ]
-                                }
-                            ],
-                            "attributes": [],
-                            "authentication": {
-                                "force_password_reset": false
-                            },
-                            "company": "",
-                            "customer_group_id": 0,
-                            "email": "nathanielhornblower@testing.com",
-                            "first_name": "Nathaniel",
-                            "last_name": "Hornblower",
-                            "notes": "",
-                            "phone": "123456788900",
-                            "registration_ip_address": "64.183.182.114",
-                            "tax_exempt_category": "",
-                            "date_created": "2018-11-13T17:55:36Z",
-                            "date_modified": "2018-11-13T17:55:36Z",
-                            "attribute_count": 0,
-                            "form_fields": [
-                                {
-                                    "name": "AccountSignUpField",
-                                    "value": ""
-                                }
-                            ],
-                            "accepts_product_review_abandoned_cart_emails": true,
-                            "store_credit_amounts": [
-                                {
-                                    "amount": 0
-                                }
-                            ]
-                        },
-                        {
-                            "id": 15,
-                            "address_count": 3,
-                            "addresses": [
-                                {
-                                    "id": 25,
-                                    "address1": "221B Baker Street",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "London",
-                                    "company": "",
-                                    "country": "United Kingdom",
-                                    "country_code": "GB",
-                                    "customer_id": 15,
-                                    "first_name": "Patricia",
-                                    "last_name": "Moriarty",
-                                    "phone": "1234567890",
-                                    "postal_code": "NW1 5LR",
-                                    "state_or_province": "UK",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": ""
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": 33,
-                                    "address1": "161 Sajik-ro",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Seoul",
-                                    "company": "",
-                                    "country": "Korea, Republic of",
-                                    "country_code": "KR",
-                                    "customer_id": 15,
-                                    "first_name": "Patricia",
-                                    "last_name": "Moriarty",
-                                    "phone": "5121234567",
-                                    "postal_code": "Jongno-gu",
-                                    "state_or_province": "Sejongno",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": ""
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": 34,
-                                    "address1": "161 Sajik-ro",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Seoul",
-                                    "company": "",
-                                    "country": "Korea, Republic of",
-                                    "country_code": "KR",
-                                    "customer_id": 15,
-                                    "first_name": "Patricia",
-                                    "last_name": "Moriarty",
-                                    "phone": "5121234567",
-                                    "postal_code": "Jongno-gu",
-                                    "state_or_province": "Sejongno",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": ""
-                                        }
-                                    ]
-                                }
-                            ],
-                            "attributes": [],
-                            "authentication": {
-                                "force_password_reset": false
-                            },
-                            "company": "",
-                            "customer_group_id": 0,
-                            "email": "patriciamoriarty@test.com",
-                            "first_name": "Patricia",
-                            "last_name": "Moriarty",
-                            "notes": "",
-                            "phone": "5122134567",
-                            "registration_ip_address": "64.183.182.114",
-                            "tax_exempt_category": "",
-                            "date_created": "2018-11-13T17:57:33Z",
-                            "date_modified": "2018-11-13T17:57:33Z",
-                            "attribute_count": 0,
-                            "form_fields": [
-                                {
-                                    "name": "AccountSignUpField",
-                                    "value": ""
-                                }
-                            ],
-                            "accepts_product_review_abandoned_cart_emails": true,
-                            "store_credit_amounts": [
-                                {
-                                    "amount": 43.18
-                                }
-                            ]
-                        },
-                        {
-                            "id": 18,
-                            "address_count": 1,
-                            "addresses": [
-                                {
-                                    "id": 27,
-                                    "address1": "Mauna Kea Access Rd",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Hilo",
-                                    "company": "",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 18,
-                                    "first_name": "Dwayne",
-                                    "last_name": "Cole",
-                                    "phone": "8081234567",
-                                    "postal_code": "96720",
-                                    "state_or_province": "Hawaii",
-                                    "form_fields": []
-                                }
-                            ],
-                            "attributes": [],
-                            "authentication": {
-                                "force_password_reset": false
-                            },
-                            "company": "",
-                            "customer_group_id": 5,
-                            "email": "dwaynecole@testing.com",
-                            "first_name": "Dwayne",
-                            "last_name": "Cole",
-                            "notes": "",
-                            "phone": "1234567890",
-                            "registration_ip_address": "",
-                            "tax_exempt_category": "",
-                            "date_created": "2018-11-13T18:38:31Z",
-                            "date_modified": "2019-01-29T20:41:52Z",
-                            "attribute_count": 0,
-                            "form_fields": [],
-                            "accepts_product_review_abandoned_cart_emails": false,
-                            "store_credit_amounts": [
-                                {
-                                    "amount": 0
-                                }
-                            ]
-                        },
-                        {
-                            "id": 19,
-                            "address_count": 1,
-                            "addresses": [
-                                {
-                                    "id": 28,
-                                    "address1": "Rue de Rivoli",
-                                    "address2": "",
-                                    "address_type": "commercial",
-                                    "city": "Paris",
-                                    "company": "",
-                                    "country": "France",
-                                    "country_code": "FR",
-                                    "customer_id": 19,
-                                    "first_name": "Caden",
-                                    "last_name": "Whitfield",
-                                    "phone": "+33(0)140205050",
-                                    "postal_code": "75001",
-                                    "state_or_province": "France",
-                                    "form_fields": []
-                                }
-                            ],
-                            "attributes": [],
-                            "authentication": {
-                                "force_password_reset": false
-                            },
-                            "company": "",
-                            "customer_group_id": 7,
-                            "email": "cadenwhitfield@testing.com",
-                            "first_name": "Caden",
-                            "last_name": "Whitfield",
-                            "notes": "",
-                            "phone": "1234567890",
-                            "registration_ip_address": "",
-                            "tax_exempt_category": "",
-                            "date_created": "2018-11-13T20:41:18Z",
-                            "date_modified": "2019-02-12T17:47:47Z",
-                            "attribute_count": 0,
-                            "form_fields": [],
-                            "accepts_product_review_abandoned_cart_emails": false,
-                            "store_credit_amounts": [
-                                {
-                                    "amount": 0
-                                }
-                            ]
-                        },
-                        {
-                            "id": 20,
-                            "address_count": 3,
-                            "addresses": [
-                                {
-                                    "id": 29,
-                                    "address1": "5555 Hermann Park Dr",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Houston",
-                                    "company": "",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 20,
-                                    "first_name": "Alice",
-                                    "last_name": "Golightly",
-                                    "phone": "8901234564",
-                                    "postal_code": "77030",
-                                    "state_or_province": "Texas",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": ""
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": 50,
-                                    "address1": "5555 Hermann Park Dr",
-                                    "address2": "",
-                                    "address_type": "residential",
-                                    "city": "Houston",
-                                    "company": "",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 20,
-                                    "first_name": "Alice",
-                                    "last_name": "Golightly",
-                                    "phone": "8901234564",
-                                    "postal_code": "77030",
-                                    "state_or_province": "Texas",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": ""
-                                        }
-                                    ]
-                                }
-                            ],
-                            "attributes": [],
-                            "authentication": {
-                                "force_password_reset": false
-                            },
-                            "company": "",
-                            "customer_group_id": 5,
-                            "email": "golightly5@testing.com",
-                            "first_name": "Alice",
-                            "last_name": "Golightly",
-                            "notes": "",
-                            "phone": "1234567840",
-                            "registration_ip_address": "",
-                            "tax_exempt_category": "",
-                            "date_created": "2018-11-13T20:42:16Z",
-                            "date_modified": "2019-05-13T17:59:52Z",
-                            "attribute_count": 0,
-                            "form_fields": [
-                                {
-                                    "name": "Account Sign Up Field",
-                                    "value": "Account Sign Up Fields"
-                                }
-                            ],
-                            "accepts_product_review_abandoned_cart_emails": false,
-                            "store_credit_amounts": [
-                                {
-                                    "amount": 0
-                                }
-                            ]
-                        },
-                        {
-                            "id": 29,
-                            "address_count": 4,
-                            "addresses": [
-                                {
-                                    "id": 43,
-                                    "address1": "Bennelong Point",
-                                    "address2": "Number 410",
-                                    "address_type": "commercial",
-                                    "city": "Sydney",
-                                    "company": "",
-                                    "country": "Australia",
-                                    "country_code": "AU",
-                                    "customer_id": 29,
-                                    "first_name": "John",
-                                    "last_name": "Doe",
-                                    "phone": "1234567890",
-                                    "postal_code": "2000",
-                                    "state_or_province": "New South Wales",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": ""
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": 44,
-                                    "address1": "123 West Street",
-                                    "address2": "654",
-                                    "address_type": "residential",
-                                    "city": "Akron",
-                                    "company": "",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 29,
-                                    "first_name": "John",
-                                    "last_name": "Doe",
-                                    "phone": "1234567890",
-                                    "postal_code": "44325",
-                                    "state_or_province": "Ohio",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": "Hello Delivery"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": 53,
-                                    "address1": "Bennelong Point",
-                                    "address2": "Number 410",
-                                    "address_type": "residential",
-                                    "city": "Sydney",
-                                    "company": "",
-                                    "country": "Australia",
-                                    "country_code": "AU",
-                                    "customer_id": 29,
-                                    "first_name": "John",
-                                    "last_name": "Doe",
-                                    "phone": "1234567890",
-                                    "postal_code": "2000",
-                                    "state_or_province": "New South Wales",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": "Hello Delivery"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "id": 54,
-                                    "address1": "Bennelong Point",
-                                    "address2": "Number 410",
-                                    "address_type": "residential",
-                                    "city": "Sydney",
-                                    "company": "",
-                                    "country": "Australia",
-                                    "country_code": "AU",
-                                    "customer_id": 29,
-                                    "first_name": "John",
-                                    "last_name": "Doe",
-                                    "phone": "1234567890",
-                                    "postal_code": "2000",
-                                    "state_or_province": "New South Wales",
-                                    "form_fields": [
-                                        {
-                                            "name": "Delivery Instructions",
-                                            "value": "Hello Delivery"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "attributes": [
-                                {
-                                    "id": 5,
-                                    "customer_id": 29,
-                                    "attribute_id": 1,
-                                    "attribute_value": "45",
-                                    "date_created": "2019-02-27T21:53:29Z",
-                                    "date_modified": "2019-02-27T21:53:29Z"
-                                },
-                                {
-                                    "id": 6,
-                                    "customer_id": 29,
-                                    "attribute_id": 2,
-                                    "attribute_value": "12",
-                                    "date_created": "2019-02-27T21:53:29Z",
-                                    "date_modified": "2019-02-27T21:53:29Z"
-                                }
-                            ],
-                            "authentication": {
-                                "force_password_reset": false
-                            },
-                            "company": "BigCommerce",
-                            "customer_group_id": 5,
-                            "email": "johndoe@example.com",
-                            "first_name": "John",
-                            "last_name": "Doe",
-                            "notes": "Warehouse",
-                            "phone": "1234567890",
-                            "registration_ip_address": "",
-                            "tax_exempt_category": "",
-                            "date_created": "2019-02-27T21:53:29Z",
-                            "date_modified": "2019-03-07T15:32:52Z",
-                            "attribute_count": 2,
-                            "form_fields": [
-                                {
-                                    "name": "Account Sign Up Field",
-                                    "value": "Sign up Field"
-                                }
-                            ],
-                            "accepts_product_review_abandoned_cart_emails": false,
-                            "store_credit_amounts": [
-                                {
-                                    "amount": 0
-                                }
-                            ]
-                        },
-                        {
-                            "id": 30,
-                            "address_count": 2,
-                            "addresses": [
-                                {
-                                    "id": 51,
-                                    "address1": "Bennelong Point ",
-                                    "address2": "",
-                                    "address_type": "commercial",
-                                    "city": "Sydney",
-                                    "company": "",
-                                    "country": "Australia",
-                                    "country_code": "AU",
-                                    "customer_id": 30,
-                                    "first_name": "John",
-                                    "last_name": "Doe",
-                                    "phone": "1234567890",
-                                    "postal_code": "2000",
-                                    "state_or_province": "New South Wales",
-                                    "form_fields": []
-                                },
-                                {
-                                    "id": 52,
-                                    "address1": "111 E West Street",
-                                    "address2": "654",
-                                    "address_type": "residential",
-                                    "city": "Akron",
-                                    "company": "",
-                                    "country": "United States",
-                                    "country_code": "US",
-                                    "customer_id": 30,
-                                    "first_name": "John",
-                                    "last_name": "Doe",
-                                    "phone": "1234567890",
-                                    "postal_code": "44325",
-                                    "state_or_province": "Ohio",
-                                    "form_fields": []
-                                }
-                            ],
-                            "attributes": [
-                                {
-                                    "id": 7,
-                                    "customer_id": 30,
-                                    "attribute_id": 1,
-                                    "attribute_value": "33",
-                                    "date_created": "2019-04-02T19:31:43Z",
-                                    "date_modified": "2019-04-02T19:51:39Z"
-                                },
-                                {
-                                    "id": 8,
-                                    "customer_id": 30,
-                                    "attribute_id": 2,
-                                    "attribute_value": "12",
-                                    "date_created": "2019-04-02T19:31:43Z",
-                                    "date_modified": "2019-04-02T19:31:43Z"
-                                }
-                            ],
-                            "authentication": {
-                                "force_password_reset": false
-                            },
-                            "company": "BigCommerce",
-                            "customer_group_id": 5,
-                            "email": "johndoe1@example.com",
-                            "first_name": "John",
-                            "last_name": "Doe",
-                            "notes": "New notes!!! 4/17/19",
-                            "phone": "1234567890",
-                            "registration_ip_address": "",
-                            "tax_exempt_category": "",
-                            "date_created": "2019-04-02T19:31:43Z",
-                            "date_modified": "2019-05-06T18:56:45Z",
-                            "attribute_count": 2,
-                            "form_fields": [
-                                {
-                                    "name": "Account Sign Up Field",
-                                    "value": "Account Sign Up Field"
-                                }
-                            ],
-                            "accepts_product_review_abandoned_cart_emails": false,
-                            "store_credit_amounts": [
-                                {
-                                    "amount": 0
-                                }
-                            ]
-                        }
-                    ],
-                    "meta": {
-                        "pagination": {
-                            "total": 9,
-                            "count": 9,
-                            "per_page": 50,
-                            "current_page": 1,
-                            "total_pages": 1
-                        }
-                    }
-                }
+              value:
+                data:
+                - id: 11
+                  address_count: 8
+                  addresses:
+                  - id: 16
+                    address1: 555 East Street
+                    address2: ''
+                    address_type: residential
+                    city: Austin
+                    company: ''
+                    country: United States
+                    country_code: US
+                    customer_id: 11
+                    first_name: Jane
+                    last_name: Doe
+                    phone: '1234567890'
+                    postal_code: '78108'
+                    state_or_province: Texas
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: Leave in backyard
+                  - id: 23
+                    address1: 111 E West Street
+                    address2: '654'
+                    address_type: commercial
+                    city: Akron
+                    company: BigCommerce
+                    country: United States
+                    country_code: US
+                    customer_id: 11
+                    first_name: Jane
+                    last_name: Doe
+                    phone: '1234567890'
+                    postal_code: '44325'
+                    state_or_province: Ohio
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: ''
+                  - id: 30
+                    address1: 122 First Street
+                    address2: ''
+                    address_type: residential
+                    city: Austin
+                    company: ''
+                    country: United States
+                    country_code: US
+                    customer_id: 11
+                    first_name: Jon
+                    last_name: Doe
+                    phone: '6789012345'
+                    postal_code: '78726'
+                    state_or_province: Texas
+                    form_fields: []
+                  - id: 46
+                    address1: 666 Sussex St
+                    address2: ''
+                    address_type: residential
+                    city: Anywhere
+                    company: Acme Pty Ltd
+                    country: United States
+                    country_code: US
+                    customer_id: 11
+                    first_name: Trishy
+                    last_name: Test
+                    phone: ''
+                    postal_code: '12345'
+                    state_or_province: Some State
+                    form_fields: []
+                  - id: 55
+                    address1: 123 Main Street
+                    address2: ''
+                    address_type: commercial
+                    city: Austin
+                    company: BigCommerce
+                    country: United States
+                    country_code: US
+                    customer_id: 11
+                    first_name: Jane
+                    last_name: Doe
+                    phone: 123-345-7890
+                    postal_code: '78726'
+                    state_or_province: Texas
+                    form_fields: []
+                  - id: 56
+                    address1: 2234 Main Street
+                    address2: ''
+                    address_type: residential
+                    city: Austin
+                    company: BigCommerce
+                    country: United States
+                    country_code: US
+                    customer_id: 11
+                    first_name: Jane
+                    last_name: Doe
+                    phone: 123-345-7890
+                    postal_code: '78726'
+                    state_or_province: Texas
+                    form_fields: []
+                  - id: 59
+                    address1: 122 First Street
+                    address2: ''
+                    address_type: residential
+                    city: Austin
+                    company: ''
+                    country: United States
+                    country_code: US
+                    customer_id: 11
+                    first_name: Jon
+                    last_name: Doe
+                    phone: '6789012345'
+                    postal_code: '78726'
+                    state_or_province: Texas
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: Leave in backyard
+                  attributes:
+                  - id: 1
+                    customer_id: 11
+                    attribute_id: 1
+                    attribute_value: '52'
+                    date_created: '2018-11-14T18:58:08Z'
+                    date_modified: '2019-02-19T19:26:21Z'
+                  authentication:
+                    force_password_reset: false
+                  company: ''
+                  customer_group_id: 0
+                  email: janedoe@example.com
+                  first_name: Jane
+                  last_name: Doe
+                  notes: ''
+                  phone: '1234567890'
+                  registration_ip_address: ''
+                  tax_exempt_category: ''
+                  date_created: '2018-09-05T13:43:54Z'
+                  date_modified: '2019-02-21T18:03:59Z'
+                  attribute_count: 1
+                  form_fields:
+                  - name: AccountSignUpField
+                    value: 345678ABC
+                  accepts_product_review_abandoned_cart_emails: true
+                  store_credit_amounts:
+                  - amount: 0
+                - id: 14
+                  address_count: 1
+                  addresses:
+                  - id: 24
+                    address1: St Katharine's & Wapping
+                    address2: ''
+                    address_type: residential
+                    city: London
+                    company: ''
+                    country: United Kingdom
+                    country_code: GB
+                    customer_id: 14
+                    first_name: Nathaniel
+                    last_name: Hornblower
+                    phone: '5122134567'
+                    postal_code: EC3N 4AB
+                    state_or_province: UK
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: ''
+                  attributes: []
+                  authentication:
+                    force_password_reset: false
+                  company: ''
+                  customer_group_id: 0
+                  email: nathanielhornblower@testing.com
+                  first_name: Nathaniel
+                  last_name: Hornblower
+                  notes: ''
+                  phone: '123456788900'
+                  registration_ip_address: 64.183.182.114
+                  tax_exempt_category: ''
+                  date_created: '2018-11-13T17:55:36Z'
+                  date_modified: '2018-11-13T17:55:36Z'
+                  attribute_count: 0
+                  form_fields:
+                  - name: AccountSignUpField
+                    value: ''
+                  accepts_product_review_abandoned_cart_emails: true
+                  store_credit_amounts:
+                  - amount: 0
+                - id: 15
+                  address_count: 3
+                  addresses:
+                  - id: 25
+                    address1: 221B Baker Street
+                    address2: ''
+                    address_type: residential
+                    city: London
+                    company: ''
+                    country: United Kingdom
+                    country_code: GB
+                    customer_id: 15
+                    first_name: Patricia
+                    last_name: Moriarty
+                    phone: '1234567890'
+                    postal_code: NW1 5LR
+                    state_or_province: UK
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: ''
+                  - id: 33
+                    address1: 161 Sajik-ro
+                    address2: ''
+                    address_type: residential
+                    city: Seoul
+                    company: ''
+                    country: Korea, Republic of
+                    country_code: KR
+                    customer_id: 15
+                    first_name: Patricia
+                    last_name: Moriarty
+                    phone: '5121234567'
+                    postal_code: Jongno-gu
+                    state_or_province: Sejongno
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: ''
+                  - id: 34
+                    address1: 161 Sajik-ro
+                    address2: ''
+                    address_type: residential
+                    city: Seoul
+                    company: ''
+                    country: Korea, Republic of
+                    country_code: KR
+                    customer_id: 15
+                    first_name: Patricia
+                    last_name: Moriarty
+                    phone: '5121234567'
+                    postal_code: Jongno-gu
+                    state_or_province: Sejongno
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: ''
+                  attributes: []
+                  authentication:
+                    force_password_reset: false
+                  company: ''
+                  customer_group_id: 0
+                  email: patriciamoriarty@test.com
+                  first_name: Patricia
+                  last_name: Moriarty
+                  notes: ''
+                  phone: '5122134567'
+                  registration_ip_address: 64.183.182.114
+                  tax_exempt_category: ''
+                  date_created: '2018-11-13T17:57:33Z'
+                  date_modified: '2018-11-13T17:57:33Z'
+                  attribute_count: 0
+                  form_fields:
+                  - name: AccountSignUpField
+                    value: ''
+                  accepts_product_review_abandoned_cart_emails: true
+                  store_credit_amounts:
+                  - amount: 43.18
+                - id: 18
+                  address_count: 1
+                  addresses:
+                  - id: 27
+                    address1: Mauna Kea Access Rd
+                    address2: ''
+                    address_type: residential
+                    city: Hilo
+                    company: ''
+                    country: United States
+                    country_code: US
+                    customer_id: 18
+                    first_name: Dwayne
+                    last_name: Cole
+                    phone: '8081234567'
+                    postal_code: '96720'
+                    state_or_province: Hawaii
+                    form_fields: []
+                  attributes: []
+                  authentication:
+                    force_password_reset: false
+                  company: ''
+                  customer_group_id: 5
+                  email: dwaynecole@testing.com
+                  first_name: Dwayne
+                  last_name: Cole
+                  notes: ''
+                  phone: '1234567890'
+                  registration_ip_address: ''
+                  tax_exempt_category: ''
+                  date_created: '2018-11-13T18:38:31Z'
+                  date_modified: '2019-01-29T20:41:52Z'
+                  attribute_count: 0
+                  form_fields: []
+                  accepts_product_review_abandoned_cart_emails: false
+                  store_credit_amounts:
+                  - amount: 0
+                - id: 19
+                  address_count: 1
+                  addresses:
+                  - id: 28
+                    address1: Rue de Rivoli
+                    address2: ''
+                    address_type: commercial
+                    city: Paris
+                    company: ''
+                    country: France
+                    country_code: FR
+                    customer_id: 19
+                    first_name: Caden
+                    last_name: Whitfield
+                    phone: "+33(0)140205050"
+                    postal_code: '75001'
+                    state_or_province: France
+                    form_fields: []
+                  attributes: []
+                  authentication:
+                    force_password_reset: false
+                  company: ''
+                  customer_group_id: 7
+                  email: cadenwhitfield@testing.com
+                  first_name: Caden
+                  last_name: Whitfield
+                  notes: ''
+                  phone: '1234567890'
+                  registration_ip_address: ''
+                  tax_exempt_category: ''
+                  date_created: '2018-11-13T20:41:18Z'
+                  date_modified: '2019-02-12T17:47:47Z'
+                  attribute_count: 0
+                  form_fields: []
+                  accepts_product_review_abandoned_cart_emails: false
+                  store_credit_amounts:
+                  - amount: 0
+                - id: 20
+                  address_count: 3
+                  addresses:
+                  - id: 29
+                    address1: 5555 Hermann Park Dr
+                    address2: ''
+                    address_type: residential
+                    city: Houston
+                    company: ''
+                    country: United States
+                    country_code: US
+                    customer_id: 20
+                    first_name: Alice
+                    last_name: Golightly
+                    phone: '8901234564'
+                    postal_code: '77030'
+                    state_or_province: Texas
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: ''
+                  - id: 50
+                    address1: 5555 Hermann Park Dr
+                    address2: ''
+                    address_type: residential
+                    city: Houston
+                    company: ''
+                    country: United States
+                    country_code: US
+                    customer_id: 20
+                    first_name: Alice
+                    last_name: Golightly
+                    phone: '8901234564'
+                    postal_code: '77030'
+                    state_or_province: Texas
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: ''
+                  attributes: []
+                  authentication:
+                    force_password_reset: false
+                  company: ''
+                  customer_group_id: 5
+                  email: golightly5@testing.com
+                  first_name: Alice
+                  last_name: Golightly
+                  notes: ''
+                  phone: '1234567840'
+                  registration_ip_address: ''
+                  tax_exempt_category: ''
+                  date_created: '2018-11-13T20:42:16Z'
+                  date_modified: '2019-05-13T17:59:52Z'
+                  attribute_count: 0
+                  form_fields:
+                  - name: Account Sign Up Field
+                    value: Account Sign Up Fields
+                  accepts_product_review_abandoned_cart_emails: false
+                  store_credit_amounts:
+                  - amount: 0
+                - id: 29
+                  address_count: 4
+                  addresses:
+                  - id: 43
+                    address1: Bennelong Point
+                    address2: Number 410
+                    address_type: commercial
+                    city: Sydney
+                    company: ''
+                    country: Australia
+                    country_code: AU
+                    customer_id: 29
+                    first_name: John
+                    last_name: Doe
+                    phone: '1234567890'
+                    postal_code: '2000'
+                    state_or_province: New South Wales
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: ''
+                  - id: 44
+                    address1: 123 West Street
+                    address2: '654'
+                    address_type: residential
+                    city: Akron
+                    company: ''
+                    country: United States
+                    country_code: US
+                    customer_id: 29
+                    first_name: John
+                    last_name: Doe
+                    phone: '1234567890'
+                    postal_code: '44325'
+                    state_or_province: Ohio
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: Hello Delivery
+                  - id: 53
+                    address1: Bennelong Point
+                    address2: Number 410
+                    address_type: residential
+                    city: Sydney
+                    company: ''
+                    country: Australia
+                    country_code: AU
+                    customer_id: 29
+                    first_name: John
+                    last_name: Doe
+                    phone: '1234567890'
+                    postal_code: '2000'
+                    state_or_province: New South Wales
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: Hello Delivery
+                  - id: 54
+                    address1: Bennelong Point
+                    address2: Number 410
+                    address_type: residential
+                    city: Sydney
+                    company: ''
+                    country: Australia
+                    country_code: AU
+                    customer_id: 29
+                    first_name: John
+                    last_name: Doe
+                    phone: '1234567890'
+                    postal_code: '2000'
+                    state_or_province: New South Wales
+                    form_fields:
+                    - name: Delivery Instructions
+                      value: Hello Delivery
+                  attributes:
+                  - id: 5
+                    customer_id: 29
+                    attribute_id: 1
+                    attribute_value: '45'
+                    date_created: '2019-02-27T21:53:29Z'
+                    date_modified: '2019-02-27T21:53:29Z'
+                  - id: 6
+                    customer_id: 29
+                    attribute_id: 2
+                    attribute_value: '12'
+                    date_created: '2019-02-27T21:53:29Z'
+                    date_modified: '2019-02-27T21:53:29Z'
+                  authentication:
+                    force_password_reset: false
+                  company: BigCommerce
+                  customer_group_id: 5
+                  email: johndoe@example.com
+                  first_name: John
+                  last_name: Doe
+                  notes: Warehouse
+                  phone: '1234567890'
+                  registration_ip_address: ''
+                  tax_exempt_category: ''
+                  date_created: '2019-02-27T21:53:29Z'
+                  date_modified: '2019-03-07T15:32:52Z'
+                  attribute_count: 2
+                  form_fields:
+                  - name: Account Sign Up Field
+                    value: Sign up Field
+                  accepts_product_review_abandoned_cart_emails: false
+                  store_credit_amounts:
+                  - amount: 0
+                - id: 30
+                  address_count: 2
+                  addresses:
+                  - id: 51
+                    address1: 'Bennelong Point '
+                    address2: ''
+                    address_type: commercial
+                    city: Sydney
+                    company: ''
+                    country: Australia
+                    country_code: AU
+                    customer_id: 30
+                    first_name: John
+                    last_name: Doe
+                    phone: '1234567890'
+                    postal_code: '2000'
+                    state_or_province: New South Wales
+                    form_fields: []
+                  - id: 52
+                    address1: 111 E West Street
+                    address2: '654'
+                    address_type: residential
+                    city: Akron
+                    company: ''
+                    country: United States
+                    country_code: US
+                    customer_id: 30
+                    first_name: John
+                    last_name: Doe
+                    phone: '1234567890'
+                    postal_code: '44325'
+                    state_or_province: Ohio
+                    form_fields: []
+                  attributes:
+                  - id: 7
+                    customer_id: 30
+                    attribute_id: 1
+                    attribute_value: '33'
+                    date_created: '2019-04-02T19:31:43Z'
+                    date_modified: '2019-04-02T19:51:39Z'
+                  - id: 8
+                    customer_id: 30
+                    attribute_id: 2
+                    attribute_value: '12'
+                    date_created: '2019-04-02T19:31:43Z'
+                    date_modified: '2019-04-02T19:31:43Z'
+                  authentication:
+                    force_password_reset: false
+                  company: BigCommerce
+                  customer_group_id: 5
+                  email: johndoe1@example.com
+                  first_name: John
+                  last_name: Doe
+                  notes: New notes!!! 4/17/19
+                  phone: '1234567890'
+                  registration_ip_address: ''
+                  tax_exempt_category: ''
+                  date_created: '2019-04-02T19:31:43Z'
+                  date_modified: '2019-05-06T18:56:45Z'
+                  attribute_count: 2
+                  form_fields:
+                  - name: Account Sign Up Field
+                    value: Account Sign Up Field
+                  accepts_product_review_abandoned_cart_emails: false
+                  store_credit_amounts:
+                  - amount: 0
+                meta:
+                  pagination:
+                    total: 9
+                    count: 9
+                    per_page: 50
+                    current_page: 1
+                    total_pages: 1
     AddressCollectionResponse:
       description: ''
       content:

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -1854,9 +1854,7 @@ components:
                     date_created: '2019-02-19T18:34:16Z'
                     date_modified: '2019-02-19T18:34:16Z'
                 meta: {}
-        with include:
-          examples:
-            response:
+            with include:
               value: |-
                 {
                     "data": [


### PR DESCRIPTION
Both channels.v3 and customers.v3 specifications contain invalid examples, I have corrected these. 

This has been preventing me from using openapi tools for SDK generation (https://github.com/drwpow/openapi-typescript specifically). 