### PR TITLE
docs(orders): DEVDOCS-2729 Update Orders v2 DELETE API Reference 

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -173,8 +173,6 @@ paths:
     delete:
       description: |-
         Archives an order.
-
-        Any attempt to archive an order on a store with automatic tax enabled will fail, and will return `405 Method not allowed.`
       summary: Archive an Order
       tags:
         - Orders

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -171,7 +171,7 @@ paths:
           $ref: '#/components/responses/order_Resp'
       operationId: updateAnOrder
     delete:
-      description: |-
+      description:
         Archives an order.
       summary: Archive an Order
       tags:


### PR DESCRIPTION
## What
Remove the following copy from the DELETE /orders/{order_id} API reference description:

> Any attempt to archive an order on a store with automatic tax enabled will fail, and will return `405 Method not allowed.`

## Why
The API Reference is out of date. The existing copy was introduced when orders could be deleted, however we introduced the ability to archive orders and it's currently possible to archive orders even when an automatic tax provider is enabled.

## Testing/Proof
### Before
![image](https://user-images.githubusercontent.com/80028746/113968366-4704ec80-9876-11eb-9a0b-11603b602973.png)

### After
![image](https://user-images.githubusercontent.com/80028746/113968280-23da3d00-9876-11eb-9163-348f7d947bdc.png)

Ping: @uwikaiddi 