### PR TITLE
DEVDOCS-2725-CountryCode_checkouts.sf.yml

### DIFF
--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -822,7 +822,7 @@ paths:
               address2: Apt 1
               city: Austin
               stateOrProvinceCode: TX
-              countryCode: USA
+              countryCode: US
               postalCode: '12345'
       responses:
         '200':
@@ -993,7 +993,7 @@ paths:
               address2: Apt 1
               city: Austin
               stateOrProvinceCode: TX
-              countryCode: USA
+              countryCode: US
               postalCode: '12345'
       responses:
         '200':
@@ -1250,7 +1250,7 @@ paths:
                   address2: Apt 1
                   city: Austin
                   stateOrProvinceCode: TX
-                  countryCode: USA
+                  countryCode: US
                   postalCode: '12345'
                   customFields:
                     - {}
@@ -1266,7 +1266,7 @@ paths:
                   address2: Apt 5
                   city: Austin
                   stateOrProvinceCode: TX
-                  countryCode: USA
+                  countryCode: US
                   postalCode: '12345'
                   customFields:
                     - {}
@@ -2589,7 +2589,7 @@ definitions:
         description: ''
         type: string
       countryCode:
-        description: 'ISO 3166-1 alpha-3 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)'
+        description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
         type: string
       postalCode:
         description: ''
@@ -3157,7 +3157,7 @@ definitions:
                     description: ''
                     type: string
                   countryCode:
-                    description: 'ISO 3166-1 alpha-3 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)'
+                    description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
                     type: string
                   postalCode:
                     description: ''
@@ -3230,7 +3230,7 @@ definitions:
                           description: ''
                           type: string
                         countryCode:
-                          description: 'ISO 3166-1 alpha-3 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)'
+                          description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
                           type: string
                         postalCode:
                           description: ''
@@ -3522,7 +3522,7 @@ definitions:
             description: ''
             type: string
           countryCode:
-            description: 'ISO 3166-1 alpha-3 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)'
+            description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
             type: string
           postalCode:
             description: ''
@@ -3611,7 +3611,7 @@ definitions:
             description: ''
             type: string
           countryCode:
-            description: 'ISO 3166-1 alpha-3 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3)'
+            description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
             type: string
           postalCode:
             description: ''


### PR DESCRIPTION
[DEVDOCS-2725](https://jira.bigcommerce.com/browse/DEVDOCS-2725)
Sorry Austin, I was mistaken. Maybe this is the same thing the requestor of [DEVDOCS-2724](https://jira.bigcommerce.com/browse/DEVDOCS-2724) did. I saw USD which is the currency code and mistook it for the CountryCode.  The countryCode should be two characters. Heather stated this correctly in [DEVDOCS-2725](https://jira.bigcommerce.com/browse/DEVDOCS-2725). Output is below:

`"billingAddress":{"id":"6070bbff1a0f6","firstName":"Jane","lastName":"Doe","email":"traciporter@hotmail.com","company":"BigCommerce","address1":"123 Main Street","address2":"Apt 1","city":"Austin","shouldSaveAddress":true,"stateOrProvince":"Texas","stateOrProvinceCode":"TX","country":"United States","countryCode":"US","postalCode":"78751","phone":"","customFields":[]},"consignments":[{"id":"6070bc3353506","shippingCost":5,"handlingCost":0,"couponDiscounts":[],"discounts":[],"lineItemIds":["4bff8f68-3df3-4d8e-8146-170e1f36aebf"],"selectedShippingOption":{"id":"26fb2db4ad77b0f039328d22d2869617","type":"shipping_flatrate","description":"Flat Rate","imageUrl":"","cost":5,"transitTime":"","additionalDescription":""},"shippingAddress":{"firstName":"Jasmine","lastName":"Fail","email":"","company":"","address1":"12345 Street Ave.","address2":"","city":"Austin","stateOrProvince":"Texas","stateOrProvinceCode":"TX","country":"United States","countryCode":"US","postalCode":"78729","phone":"","customFields":[{"fieldId":"field_27","fieldValue":""}`