### PR TITLE
DEVDOCS-2767-email_templates/invoice_email.yml

### DIFF
--- a/models/email_templates/invoice_email.yml
+++ b/models/email_templates/invoice_email.yml
@@ -78,7 +78,7 @@ properties:
                   type: string
             download_url:
               type: string
-            thumbnail_url:
+            thumbnail:
               type: string
             event:
               type: object


### PR DESCRIPTION
[DEVDOCS-2767](https://jira.bigcommerce.com/browse/DEVDOCS-2767)

In Invoice Email Template Objects, changed `thumbnail_url` to `thumbnail` per testing done by Heather and Ivan.

https://bigcommerce.slack.com/archives/C012TCB5PLP/p1619101984036700