### PR TITLE
Arrayify query params

### DIFF
--- a/reference/carts.sf.yml
+++ b/reference/carts.sf.yml
@@ -141,13 +141,15 @@ paths:
             `lineItems.digitalItems.options`:  The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
 
             `lineItems.digitalItems.options,lineItems.physicalItems.options`:  The Cart returns an abbreviated result. Use this to return digital and physical options. Can also be used in a /POST to have the extended Cart object return.
+          style: form
+          explode: false
           schema:
-            type: string
-            default: 'lineItems.digitalItems.options,lineItems.physicalItems.options'
-            enum:
-              - lineItems.physicalItems.options
-              - lineItems.digitalItems.options
-              - 'lineItems.digitalItems.options,lineItems.physicalItems.options'
+            type: array
+            items:
+              type: string
+              enum:
+                - lineItems.physicalItems.options
+                - lineItems.digitalItems.options
       responses:
         '200':
           $ref: '#/components/responses/postCartsItems'
@@ -215,13 +217,15 @@ paths:
             `lineItems.digitalItems.options`:  The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
 
             `lineItems.digitalItems.options,lineItems.physicalItems.options`:  The Cart returns an abbreviated result. Use this to return digital and physical options. Can also be used in a /POST to have the extended Cart object return.
+          style: form
+          explode: false
           schema:
-            type: string
-            default: 'lineItems.digitalItems.options,lineItems.physicalItems.options'
-            enum:
-              - lineItems.physicalItems.options
-              - lineItems.digitalItems.options
-              - 'lineItems.digitalItems.options,lineItems.physicalItems.options'
+            type: array
+            items:
+              type: string
+              enum:
+                - lineItems.physicalItems.options
+                - lineItems.digitalItems.options
       requestBody:
         content:
           application/json:
@@ -284,13 +288,15 @@ paths:
             `lineItems.digitalItems.options`:  The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
 
             `lineItems.digitalItems.options,lineItems.physicalItems.options`:  The Cart returns an abbreviated result. Use this to return digital and physical options. Can also be used in a /POST to have the extended Cart object return.
+          style: form
+          explode: false
           schema:
-            type: string
-            default: 'lineItems.digitalItems.options,lineItems.physicalItems.options'
-            enum:
-              - lineItems.physicalItems.options
-              - lineItems.digitalItems.options
-              - 'lineItems.digitalItems.options,lineItems.physicalItems.options'
+            type: array
+            items:
+              type: string
+              enum:
+                - lineItems.physicalItems.options
+                - lineItems.digitalItems.options
       responses:
         '200':
           $ref: '#/components/responses/deleteCartsItems'
@@ -1514,23 +1520,28 @@ components:
         `lineItems.digitalItems.options`:  The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
 
         `lineItems.digitalItems.options,lineItems.physicalItems.options`:  The Cart returns an abbreviated result. Use this to return digital and physical options. Can also be used in a /POST to have the extended Cart object return.
+      style: form
+      explode: false
       schema:
-        type: string
-        default: 'lineItems.digitalItems.options,lineItems.physicalItems.options'
-        enum:
-          - lineItems.physicalItems.options
-          - lineItems.digitalItems.options
-          - 'lineItems.digitalItems.options,lineItems.physicalItems.options'
+        type: array
+        items:
+          type: string
+          enum:
+            - lineItems.physicalItems.options
+            - lineItems.digitalItems.options
     include:
       name: include
       in: query
       description: Include product options in specified line item types.
+      style: form
+      explode: false
       schema:
-        type: string
-        enum:
-          - lineItems.physicalItems.options
-          - lineItems.digitalItems.options
-          - 'lineItems.digitalItems.options,lineItems.physicalItems.options'
+        type: array
+        items:
+          type: string
+          enum:
+            - lineItems.physicalItems.options
+            - lineItems.digitalItems.options
   examples: {}
 x-stoplight:
   docs:

--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -123,15 +123,18 @@ paths:
             5. Creating a cart using a custom item.
         - name: include
           in: query
-          type: string
-          description: |-
-            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
-          enum:
-            - redirect_urls
-            - line_items.physical_items.options
-            - line_items.digital_items.options
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+            description: |-
+              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
+            enum:
+              - redirect_urls
+              - line_items.physical_items.options
+              - line_items.digital_items.options
         - in: header
           type: string
           default: application/json
@@ -204,15 +207,18 @@ paths:
               }
         - name: include
           in: query
-          type: string
-          description: |-
-            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
-          enum:
-            - redirect_urls
-            - line_items.physical_items.options
-            - line_items.digital_items.options
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+            description: |-
+              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
+            enum:
+              - redirect_urls
+              - line_items.physical_items.options
+              - line_items.digital_items.options
         - in: header
           type: string
           default: application/json
@@ -306,15 +312,18 @@ paths:
                 list_price: 12.5
         - name: include
           in: query
-          type: string
-          description: |-
-            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
-          enum:
-            - redirect_urls
-            - line_items.physical_items.options
-            - line_items.digital_items.options
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+            description: |-
+              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
+            enum:
+              - redirect_urls
+              - line_items.physical_items.options
+              - line_items.digital_items.options
         - in: header
           type: string
           default: application/json
@@ -362,15 +371,18 @@ paths:
           required: true
         - name: include
           in: query
-          type: string
-          description: |-
-            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
-          enum:
-            - redirect_urls
-            - line_items.physical_items.options
-            - line_items.digital_items.options
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+            description: |-
+              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
+            enum:
+              - redirect_urls
+              - line_items.physical_items.options
+              - line_items.digital_items.options
       tags:
         - Cart Items
       responses:
@@ -458,15 +470,18 @@ paths:
           description: The identifier of a specific cart.
         - name: include
           in: query
-          type: string
-          description: |-
-            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
-          enum:
-            - redirect_urls
-            - line_items.physical_items.options
-            - line_items.digital_items.options
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+            description: |-
+              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
+            enum:
+              - redirect_urls
+              - line_items.physical_items.options
+              - line_items.digital_items.options
         - in: header
           type: string
           default: application/json
@@ -509,15 +524,18 @@ paths:
               customer_id: 5
         - name: include
           in: query
-          type: string
-          description: |-
-            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
-          enum:
-            - redirect_urls
-            - line_items.physical_items.options
-            - line_items.digital_items.options
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+            description: |-
+              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
+            enum:
+              - redirect_urls
+              - line_items.physical_items.options
+              - line_items.digital_items.options
         - in: header
           type: string
           default: application/json
@@ -2632,15 +2650,18 @@ parameters:
   line_items:
     name: include
     in: query
-    type: string
-    description: |-
-      * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-      * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-      * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
-    enum:
-      - redirect_urls
-      - line_items.physical_items.options
-      - line_items.digital_items.options
+    type: array
+    collectionFormat: csv
+    items:
+      type: string
+      description: |-
+        * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+        * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+        * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
+      enum:
+        - redirect_urls
+        - line_items.physical_items.options
+        - line_items.digital_items.options
 schemes:
   - https
 security:

--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -125,12 +125,12 @@ paths:
           in: query
           type: array
           collectionFormat: csv
+          description: |-
+            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
           items:
             type: string
-            description: |-
-              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
             enum:
               - redirect_urls
               - line_items.physical_items.options
@@ -209,12 +209,12 @@ paths:
           in: query
           type: array
           collectionFormat: csv
+          description: |-
+            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
           items:
             type: string
-            description: |-
-              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
             enum:
               - redirect_urls
               - line_items.physical_items.options
@@ -314,12 +314,12 @@ paths:
           in: query
           type: array
           collectionFormat: csv
+          description: |-
+            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
           items:
             type: string
-            description: |-
-              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
             enum:
               - redirect_urls
               - line_items.physical_items.options
@@ -373,12 +373,12 @@ paths:
           in: query
           type: array
           collectionFormat: csv
+          description: |-
+            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
           items:
             type: string
-            description: |-
-              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
             enum:
               - redirect_urls
               - line_items.physical_items.options
@@ -472,12 +472,12 @@ paths:
           in: query
           type: array
           collectionFormat: csv
+          description: |-
+            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
           items:
             type: string
-            description: |-
-              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
             enum:
               - redirect_urls
               - line_items.physical_items.options
@@ -526,12 +526,12 @@ paths:
           in: query
           type: array
           collectionFormat: csv
+          description: |-
+            * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+            * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+            * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
           items:
             type: string
-            description: |-
-              * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-              * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-              * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
             enum:
               - redirect_urls
               - line_items.physical_items.options
@@ -2652,12 +2652,12 @@ parameters:
     in: query
     type: array
     collectionFormat: csv
+    description: |-
+      * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
+      * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
+      * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
     items:
       type: string
-      description: |-
-        * `redirect_urls`: Create a direct link to a Cart. This can be used during the /POST request for Carts.
-        * `line_items.physical_items.options`: The Cart returns an abbreviated result. Use this to return physical items product options. Can also be used in a /POST to have the extended Cart object return.
-        * `line_items.digital_items.options`: The Cart returns an abbreviated result. Use this to return digital items product options.  Can also be used in a /POST to have the extended Cart object return.
       enum:
         - redirect_urls
         - line_items.physical_items.options

--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -307,26 +307,35 @@ paths:
           description: 'Sub-resources to include on a product, in a comma-separated list. If `options` or `modifiers` is used, results are limited to 10 per page.'
           required: false
           in: query
-          type: string
-          enum:
-            - variants
-            - images
-            - custom_fields
-            - bulk_pricing_rules
-            - primary_image
-            - modifiers
-            - options
-            - videos
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+            enum:
+              - variants
+              - images
+              - custom_fields
+              - bulk_pricing_rules
+              - primary_image
+              - modifiers
+              - options
+              - videos
         - name: include_fields
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: availability
           description: |
             Filter items by availability. Values are: available, disabled, preorder.
@@ -772,26 +781,35 @@ paths:
           description: 'Sub-resources to include on a product, in a comma-separated list. If `options` or `modifiers` is used, results are limited to 10 per page.'
           required: false
           in: query
-          type: string
-          enum:
-            - variants
-            - images
-            - custom_fields
-            - bulk_pricing_rules
-            - primary_image
-            - modifiers
-            - options
-            - videos
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
+            enum:
+              - variants
+              - images
+              - custom_fields
+              - bulk_pricing_rules
+              - primary_image
+              - modifiers
+              - options
+              - videos
         - name: include_fields
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - in: header
           type: string
           name: Accept
@@ -1085,12 +1103,18 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - in: header
           type: string
           name: Accept
@@ -1458,7 +1482,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -1791,7 +1818,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -2061,7 +2091,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -2330,7 +2363,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -2621,7 +2657,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -2868,7 +2907,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -3390,7 +3432,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -3742,7 +3787,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -4253,7 +4301,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -5040,7 +5091,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -5350,7 +5404,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -5652,7 +5709,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -6553,7 +6613,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -7470,7 +7533,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -7869,7 +7935,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -8431,7 +8500,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -8797,7 +8869,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -9121,7 +9196,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -9397,7 +9475,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -9683,7 +9764,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -9927,7 +10011,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -10245,7 +10332,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -10480,7 +10570,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -10746,7 +10839,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -11105,7 +11201,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -11524,7 +11623,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -11886,7 +11988,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -12364,7 +12469,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -12690,7 +12798,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -13078,7 +13189,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -13604,7 +13718,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -14029,7 +14146,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -14266,7 +14386,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -14584,7 +14707,10 @@ paths:
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
           required: false
           in: query
-          type: string
+          type: array
+          collectionFormat: csv
+          items:
+            type: string
         - name: exclude_fields
           description: 'Fields to exclude, in a comma-separated list. The specified fields will be excluded from a response. The ID cannot be excluded.'
           required: false
@@ -17164,16 +17290,19 @@ parameters:
     description: 'Sub-resources to include on a product, in a comma-separated list. If `options` or `modifiers` is used, results are limited to 10 per page.'
     required: false
     in: query
-    type: string
-    enum:
-      - variants
-      - images
-      - custom_fields
-      - bulk_pricing_rules
-      - primary_image
-      - modifiers
-      - options
-      - videos
+    type: array
+    collectionFormat: csv
+    items:
+      type: string
+      enum:
+        - variants
+        - images
+        - custom_fields
+        - bulk_pricing_rules
+        - primary_image
+        - modifiers
+        - options
+        - videos
   FilterIncludeFieldsParam:
     name: include_fields
     description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'


### PR DESCRIPTION
There are a lot of query params which should be defined as _arrays_ but are instead defined as _strings_. This PR addresses some of these issues, but not all, as there are quite a lot of them.