### PR TITLE
Add missing data property to v3 response schemas

### DIFF
--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -2657,15 +2657,25 @@ responses:
   CartResponse:
     description: ''
     schema:
-      $ref: '#/definitions/Cart_Full'
+      type: object
+      properties:
+        data:
+          $ref: '#/definitions/Cart_Full'
+        meta:
+          type: object
   CartRedirectResponse:
     description: ''
     schema:
       type: object
       properties:
-        cart_url:
-          type: string
-          format: url
-        checkout_url:
-          type: string
-          format: url
+        data:
+          type: object
+          properties:
+            cart_url:
+              type: string
+              format: url
+            checkout_url:
+              type: string
+              format: url
+        meta:
+          type: object

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -806,7 +806,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomerSettingsObject'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CustomerSettingsObject'
+                  meta:
+                    type: object
               examples:
                 data:
                   value:
@@ -834,7 +839,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomerSettingsObject'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CustomerSettingsObject'
+                  meta:
+                    type: object
               examples:
                 data:
                   value:
@@ -868,7 +878,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomerChannelSettingsObject'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CustomerChannelSettingsObject'
+                  meta:
+                    type: object
               examples:
                 data:
                   value:
@@ -912,7 +927,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CustomerSettingsObject'
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/CustomerSettingsObject'
+                  meta:
+                    type: object
               examples:
                 data:
                   value:

--- a/reference/shipping.v3.yml
+++ b/reference/shipping.v3.yml
@@ -97,9 +97,14 @@ paths:
         '200':
           description: ''
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/customsInformation'
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/definitions/customsInformation'
+              meta:
+                type: object
       summary: Upsert Customs Information
       description: |-
         Creates and updates product customs information.


### PR DESCRIPTION
Some of the v3 responses schemas are missing the data and meta properties. This PR corrects those response schemas.