### PR TITLE
docs(tax): Change "Get a Connection" copy

### DIFF
--- a/reference/tax.v3.yml
+++ b/reference/tax.v3.yml
@@ -6,7 +6,7 @@ info:
 paths:
   '/tax/providers/{provider_id}/connection':
     get:
-      summary: Get a Connection
+      summary: Get Connection Status
       description: |
         Retrieve the connection status of the specified tax provider in the context of a store.
 


### PR DESCRIPTION
## What
Change title link copy from:
> Get a Connection

To:
>Get Connection Status

## Why
Introducing language that better describes the functionality.

## Testing/Proof
### Before
![image](https://user-images.githubusercontent.com/80028746/116190032-440e6500-a76d-11eb-9abb-1b696193241a.png)

### After
![image](https://user-images.githubusercontent.com/80028746/116190008-3527b280-a76d-11eb-9fe2-34230565ed96.png)

## How can this change be undone in case of failure?
Revert this PR.

ping @uwikaiddi @bigcommerce/shipping 