### PR TITLE
docs(tax): Update tax exempt and type description

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -659,7 +659,7 @@ components:
           $ref: '#/components/schemas/TaxClass'
         tax_exempt:
           type: boolean
-          description: Flag whether or not this item is always tax exempt. Gift Certificate purchases for example. Tax Exempt items should be included in the Request for auditing purposes.
+          description: Flag whether or not this item is always tax exempt. For example, for Gift Certificate purchases and order-level refunds (whereby the merchant is refunding an arbitrary amount that's less than the total refundable amount). Tax Exempt items should be included in the Request for auditing purposes.
           default: 'false'
         type:
           type: string

--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -659,12 +659,12 @@ components:
           $ref: '#/components/schemas/TaxClass'
         tax_exempt:
           type: boolean
-          description: Flag whether or not this item is always tax exempt. For example, for gift certificate purchases and order-level refunds. Tax exempt items are included in the request for auditing purposes.
+          description: Flag whether or not this item is always tax exempt. For example, gift certificate purchases and order-level refunds are tax exempt. Tax exempt items are included in the request for auditing purposes.
           default: 'false'
         type:
           type: string
           description: |-
-            The type of line item this request represents. This will depend on the items position in the request hirearchy, for example a collection of items (Which may or may not also have wrapping attached) are contained within the document request, and separately each document request has a single shipping and a single handling line item (to capture these values).
+            The type of line item this request represents. This will depend on the items position in the request hirearchy, for example a collection of items (which may or may not also have wrapping attached) are contained within the document request. Seperately, each document request has a single shipping and a single handling line item (to capture these values).
 
             The type refund is used when the tax estimate request is for an order-level refund.  
           enum:

--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -659,14 +659,14 @@ components:
           $ref: '#/components/schemas/TaxClass'
         tax_exempt:
           type: boolean
-          description: Flag whether or not this item is always tax exempt. For example, for Gift Certificate purchases and order-level refunds (whereby the merchant is refunding an arbitrary amount that's less than the total refundable amount). Tax Exempt items should be included in the Request for auditing purposes.
+          description: Flag whether or not this item is always tax exempt. For example, for gift certificate purchases and order-level refunds. Tax exempt items are included in the request for auditing purposes.
           default: 'false'
         type:
           type: string
           description: |-
             The type of line item this request represents. This will depend on the items position in the request hirearchy, for example a collection of items (Which may or may not also have wrapping attached) are contained within the document request, and separately each document request has a single shipping and a single handling line item (to capture these values).
 
-            A value of refund is included in this field when the tax estimate request is for an order-level refund.  
+            The type refund is used when the tax estimate request is for an order-level refund.  
           enum:
             - item
             - wrapping

--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -663,7 +663,10 @@ components:
           default: 'false'
         type:
           type: string
-          description: 'The type of line item this request represents. This will depend on the items position in the request hirearchy, for example a collection of items (Which may or may not also have wrapping attached) are contained within the document request, and separately each document request has a single shipping and a single handling line item (to capture these values).'
+          description: |-
+            The type of line item this request represents. This will depend on the items position in the request hirearchy, for example a collection of items (Which may or may not also have wrapping attached) are contained within the document request, and separately each document request has a single shipping and a single handling line item (to capture these values).
+
+            A value of refund is included in this field when the tax estimate request is for an order-level refund.  
           enum:
             - item
             - wrapping


### PR DESCRIPTION
## What
Updated **type** and **tax_exempt** field descriptions to also describe refund functionality.

## Why
Responding to developer feedback that the descriptions for these fields make no reference to refunds functionality.

## Testing/Proof
### Before
![image](https://user-images.githubusercontent.com/80028746/116192665-83d74b80-a771-11eb-87f0-8efb24b8efd1.png)

### After
![image](https://user-images.githubusercontent.com/80028746/116193320-85554380-a772-11eb-84ca-9ab82b3f7528.png)

## How can this change be undone in case of failure?
Revert this PR.

ping @uwikaiddi @bigcommerce/orders @bigcommerce/shipping 