### PR TITLE
DEVDOCS-2735-fix-links

### DIFF
--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -6,7 +6,7 @@ info:
     Manage products, brands and categories. To learn more about catalog resources see [Catalog Overview](https://developer.bigcommerce.com/api-docs/catalog/products-overview).
 
     - [Authentication](#authentication)
-    - [Differentiating Variants & Modifiers](#variants-and-modifiers)
+    - [Differentiating Variants and Modifiers](#differentiating-variants-and-modifiers)
     - [Available Endpoints](#available-endpoints)
     - [Resources](#resources)
 

--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -7,8 +7,8 @@ info:
 
     - [Authentication](#authentication)
     - [Channels](#channels)
-    - [Channel Listings](#channel-listings)
-    - [Channel Site](#channel-site)
+    - [Channel listings](#channel-listings)
+    - [Channel site](#channel-site)
     - [Resources](#resources)
 
     ## Authentication
@@ -30,9 +30,9 @@ info:
     | Channel Settings                             | modify     | `store_channel_settings`                      |
     | Channel Settings                             | read-only  | `store_channel_settings_read_only`            |
 
-    ## [Channels](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels)
+    ## Channels
 
-    A channel is anywhere a merchant sells their products. This encompasses headless storefronts, marketplaces, POS systems, and marketing platforms.
+    A [channel](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channels) is anywhere a merchant sells their products. This encompasses headless storefronts, marketplaces, POS systems, and marketing platforms.
 
     ### Platform
 
@@ -77,13 +77,13 @@ info:
     </div>
     </div>
 
-    ## [Channel Listings](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channel-listings)
+    ## Channel listings
 
-    Channel listings allow you to manage catalog differences among different storefronts or marketplaces.
+    [Channel listings](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channel-listings) allow you to manage catalog differences among different storefronts or marketplaces.
 
-    ## [Channel Site](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channel-site)
+    ## Channel site
 
-    A site refers to the domain associated with a channel.
+    A [Channel site](https://developer.bigcommerce.com/api-reference/cart-checkout/channels-listings-api/channel-site) refers to the domain associated with a channel.
 
     ## Resources
 


### PR DESCRIPTION
Fix links in [Channels](https://developer.bigcommerce.com/api-reference/store-management/channels) and in [Catalog](https://developer.bigcommerce.com/api-reference/store-management/catalog) API Reference pages.