### PR TITLE
docs(checkout): CHECKOUT-5767 Adding an extra note to ensure developers understand the trigger point for AbandonedCart notification

### DIFF
--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -792,6 +792,7 @@ paths:
 
         > ### Note
         > * The `email` property is only required if the customer is a guest shopper. Otherwise, it is set automatically.
+        > * Sending `email` property as a payload in POST request triggers the abandoned cart notification process.
         > * The Send a Test Request feature is not currently supported for this endpoint.
 
         </div>


### PR DESCRIPTION
This JIRA ticket https://jira.bigcommerce.com/browse/CHECKOUT-5767 requests documentation for developers who implement their own checkout and wants to know how AbandonedCart notification are triggered.
Also related to the discussion originated from this ticket: https://jira.bigcommerce.com/browse/CHECKOUT-5667