### PR TITLE
Improve API Reference copy for GET Order Shipping Addresses Quotes 

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -881,7 +881,7 @@ paths:
           $ref: '#/components/responses/shippingQuotes_Resp'
       summary: Get Order Shipping Quotes
       description: |-
-        Gets all shipping options persisted on an order.
+        Gets all shipping quotes persisted on an order.
 
         This is a read only endpoint and the output can vary based on the shipping quote. A shipping quote can only be generated using the storefront at this time. Orders that are created in the control panel or via the API return a 204 for this endpoint since a shipping quote is not generated during that process.
       parameters:

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -881,7 +881,7 @@ paths:
           $ref: '#/components/responses/shippingQuotes_Resp'
       summary: Get Order Shipping Quotes
       description: |-
-        Gets all shipping quotes associated to an order.
+        Gets all shipping options persisted on an order.
 
         This is a read only endpoint and the output can vary based on the shipping quote. A shipping quote can only be generated using the storefront at this time. Orders that are created in the control panel or via the API return a 204 for this endpoint since a shipping quote is not generated during that process.
       parameters:


### PR DESCRIPTION
## What
Updated copy with API Reference for GET Order Shipping Addresses Quotes

## Why
Previous copy suggested that all shipping quotes presented to shopper in storefront are returned in the response, when in fact, only the shipping quotes that were selected and persisted are returned.

## Testing/Proof
### Before
<img width="861" alt="image" src="https://user-images.githubusercontent.com/80028746/121468336-f63c7c00-c9fd-11eb-8fc2-5a77c83aba72.png">

### After
<img width="793" alt="image" src="https://user-images.githubusercontent.com/80028746/121468404-13714a80-c9fe-11eb-9f86-79fa1fe8f56f.png">

Ping: @aglensmith 