### PR TITLE
docs(payment): Add postal_code to list stored instrument

### DIFF
--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -1729,16 +1729,15 @@ paths:
                         first_name: Tester
                         last_name: Tester
                         email: example@email.com
-                        company: string
+                        company: Test Company
                         address1: 1 Sample Street
-                        address2: string
-                        city: string
+                        address2: Appt 1
+                        city: Las Vegas
+                        postal_code: '90854'
                         state_or_province: Nevada
                         state_or_province_code: NV
                         country_code: US
                         phone: 101-192-0293
-                        store_credit_amounts:
-                          - amount: 43.15
         '401':
           description: Unauthorized
           content:
@@ -3658,13 +3657,19 @@ components:
         company:
           type: string
           description: Company of the card holder
+          example: Test Company
         address1:
           type: string
           example: 1 Sample Street
         address2:
           type: string
+          example: Appt 1
         city:
           type: string
+          example: Las Vegas
+        postal_code:
+          type: string
+          example: '90854'
         state_or_province:
           type: string
           description: Represents state or province


### PR DESCRIPTION
##What
Add missing `postal_code` field to public documentation.
Bonus: removes `store_credit` field which should not have been there.

## Why
`postal_code` field was originally missed and has been added to the API.

## Proof
![image](https://user-images.githubusercontent.com/1313863/128341604-08bd1fff-dcae-4b59-a137-43cd9cf26488.png)

ping @uwikaiddi @bigcommerce/dev-docs 