### PR TITLE
DEVDOCS-3011 Update POST Create a Customer Address info

### DIFF
--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -521,18 +521,7 @@ paths:
       tags:
         - Customer Addresses
     post:
-      description: |-
-        Creates a Customer Address. Multiple customer addresses can be created in one call.
-
-        **Required Fields**
-        * first_name
-        * city
-        * customer_id
-        * country_code
-        * state_or_province
-        * last_name
-        * address1
-        * postal_code
+      description: Creates a Customer Address. Multiple customer addresses can be created in one call.
       summary: Create a Customer Address
       operationId: CustomersAddressesPost
       deprecated: false
@@ -554,21 +543,7 @@ paths:
               type: array
               items:
                 $ref: '#/components/schemas/address_Post'
-            examples:
-              example-1:
-                value:
-                  - first_name: string
-                    last_name: string
-                    company: string
-                    address1: string
-                    address2: string
-                    city: string
-                    state_or_province: New South Wales
-                    postal_code: string
-                    country_code: AU
-                    phone: string
-                    address_type: residential
-                    customer_id: 1
+            examples: {}
         required: true
         x-examples:
           application/json:
@@ -585,7 +560,7 @@ paths:
               customer_id: 11
       responses:
         '200':
-          $ref: '#/components/responses/AddressCollectionResponse'
+          $ref: '#/components/responses/AddressCollectionResponsePostPut'
         '422':
           description: |
             The `Address` was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.
@@ -657,7 +632,7 @@ paths:
               customer_id: 23
       responses:
         '200':
-          $ref: '#/components/responses/AddressCollectionResponse'
+          $ref: '#/components/responses/AddressCollectionResponsePostPut'
         '422':
           description: |
             The `Address` was not valid. This is the result of missing required fields, or of invalid data. See the response for more details.
@@ -922,17 +897,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CustomerChannelSettingsObject'        
+              $ref: '#/components/schemas/CustomerChannelSettingsObject'
             examples:
-                example-1:
-                  value:
-                    privacy_settings:
-                      ask_shopper_for_tracking_consent: true
-                      policy_url: 'https://bigcommmerce.com/policy'
-                    customer_group_settings:
-                      guest_customer_group_id: 0
-                      default_customer_group_id: 0
-                    allow_global_logins: true
+              example-1:
+                value:
+                  privacy_settings:
+                    ask_shopper_for_tracking_consent: true
+                    policy_url: 'https://bigcommmerce.com/policy'
+                  customer_group_settings:
+                    guest_customer_group_id: 0
+                    default_customer_group_id: 0
+                  allow_global_logins: true
         required: true
       responses:
         '200':
@@ -1824,52 +1799,12 @@ components:
                   title: Address
                   type: object
                   properties:
-                    first_name:
-                      description: The first name of the customer address.
-                      type: string
-                      minLength: 1
-                      maxLength: 255
-                    last_name:
-                      description: The last name of the customer address.
-                      type: string
-                      minLength: 1
-                      maxLength: 255
-                    company:
-                      description: The company of the customer address.
-                      type: string
-                      minLength: 0
-                      maxLength: 255
                     address1:
                       description: The address 1 line.
                       type: string
                     address2:
                       description: The address 2 line.
                       type: string
-                    city:
-                      description: The city of the customer address.
-                      type: string
-                      minLength: 0
-                      maxLength: 100
-                    state_or_province:
-                      description: The state or province name
-                      type: string
-                      minLength: 0
-                      maxLength: 100
-                    postal_code:
-                      description: The postal code of the customer address.
-                      type: string
-                      minLength: 0
-                      maxLength: 30
-                    country_code:
-                      description: The country code of the customer address.
-                      type: string
-                      minLength: 2
-                      maxLength: 2
-                    phone:
-                      description: The phone number of the customer address.
-                      type: string
-                      minLength: 0
-                      maxLength: 50
                     address_type:
                       title: Address Type
                       description: The address type. Residential or Commercial
@@ -1878,17 +1813,57 @@ components:
                       enum:
                         - residential
                         - commercial
+                    city:
+                      description: The city of the customer address.
+                      type: string
+                      minLength: 0
+                      maxLength: 100
+                    company:
+                      description: The company of the customer address.
+                      type: string
+                      minLength: 0
+                      maxLength: 255
+                    country:
+                      description: The country name of the customer address.
+                      type: string
+                    country_code:
+                      description: The country code of the customer address.
+                      type: string
+                      minLength: 2
+                      maxLength: 2
                     customer_id:
                       description: The customer ID.
                       type: integer
                       format: int32
+                    first_name:
+                      description: The first name of the customer address.
+                      type: string
+                      minLength: 1
+                      maxLength: 255
                     id:
                       description: The unique numeric ID of the address.
                       type: integer
                       format: int32
-                    country:
-                      description: The country name of the customer address.
+                    last_name:
+                      description: The last name of the customer address.
                       type: string
+                      minLength: 1
+                      maxLength: 255
+                    phone:
+                      description: The phone number of the customer address.
+                      type: string
+                      minLength: 0
+                      maxLength: 50
+                    postal_code:
+                      description: The postal code of the customer address.
+                      type: string
+                      minLength: 0
+                      maxLength: 30
+                    state_or_province:
+                      description: The state or province name
+                      type: string
+                      minLength: 0
+                      maxLength: 100
                     form_fields:
                       description: Array of form fields. Controlled by `formfields` parameter.
                       type: array
@@ -1897,288 +1872,164 @@ components:
                           - allOf:
                               - type: object
                                 title: Form Field Value Base
-                                required:
-                                  - name
-                                  - value
-                                properties:
-                                  name:
-                                    type: string
-                                    description: The form field name.
-                                    example: color
-                                  value:
-                                    oneOf:
-                                      - type: string
-                                        example: blue
-                                      - type: number
-                                        format: double
-                                        example: 12.345
-                                      - type: array
-                                        example:
-                                          - red
-                                          - green
-                                          - black
-                                        items:
-                                          type: string
                               - type: object
-                                properties:
-                                  customer_id:
-                                    type: integer
-                                required:
-                                  - customer_id
-                            title: Customer Form Field Value
                           - allOf:
                               - type: object
                                 title: Form Field Value Base
-                                required:
-                                  - name
-                                  - value
-                                properties:
-                                  name:
-                                    type: string
-                                    description: The form field name.
-                                    example: color
-                                  value:
-                                    oneOf:
-                                      - type: string
-                                        example: blue
-                                      - type: number
-                                        format: double
-                                        example: 12.345
-                                      - type: array
-                                        example:
-                                          - red
-                                          - green
-                                          - black
-                                        items:
-                                          type: string
                               - type: object
-                                properties:
-                                  address_id:
-                                    type: integer
-                                    description: The Customer Address ID.
-                                required:
-                                  - address_id
-                            title: Customer Address Form Field Value
                         title: 'Form Field Value '
                   required:
-                    - first_name
-                    - last_name
                     - address1
                     - city
-                    - state_or_province
-                    - postal_code
                     - country_code
                     - customer_id
+                    - first_name
                     - id
+                    - last_name
+                    - postal_code
+                    - state_or_province
               meta:
                 $ref: '#/components/schemas/_metaCollection'
           examples:
             response:
               value:
                 data:
-                  - id: 16
-                    address1: 555 East Street
-                    address2: ''
+                  - address1: 123 Example Street
+                    address2: Building 4
                     address_type: residential
                     city: Austin
-                    company: ''
-                    country: United States
-                    country_code: US
-                    customer_id: 11
-                    first_name: Jane
-                    last_name: Doe
-                    phone: '1234567890'
-                    postal_code: '78751'
-                    state_or_province: Texas
-                  - id: 23
-                    address1: 111 E West Street
-                    address2: '654'
-                    address_type: commercial
-                    city: Akron
                     company: BigCommerce
                     country: United States
                     country_code: US
-                    customer_id: 11
-                    first_name: Jane
-                    last_name: Doe
-                    phone: '1234567890'
-                    postal_code: '44325'
-                    state_or_province: Ohio
-                  - id: 24
-                    address1: St Katharine's & Wapping
-                    address2: ''
-                    address_type: residential
-                    city: London
-                    company: ''
-                    country: United Kingdom
-                    country_code: GB
-                    customer_id: 14
-                    first_name: Nathaniel
-                    last_name: Hornblower
-                    phone: '5122134567'
-                    postal_code: EC3N 4AB
-                    state_or_province: UK
-                  - id: 25
-                    address1: 221B Baker Street
-                    address2: ''
-                    address_type: residential
-                    city: London
-                    company: ''
-                    country: United Kingdom
-                    country_code: GB
-                    customer_id: 15
-                    first_name: Patricia
-                    last_name: Moriarty
-                    phone: '1234567890'
-                    postal_code: NW1 5LR
-                    state_or_province: UK
-                  - id: 27
-                    address1: Mauna Kea Access Rd
-                    address2: ''
-                    address_type: residential
-                    city: Hilo
-                    company: ''
-                    country: United States
-                    country_code: US
-                    customer_id: 18
-                    first_name: Dwayne
-                    last_name: Cole
-                    phone: '8081234567'
-                    postal_code: '96720'
-                    state_or_province: Hawaii
-                  - id: 28
-                    address1: Rue de Rivoli
-                    address2: ''
-                    address_type: commercial
-                    city: Paris
-                    company: ''
-                    country: France
-                    country_code: FR
-                    customer_id: 19
-                    first_name: Caden
-                    last_name: Whitfield
-                    phone: +33(0)140205050
-                    postal_code: '75001'
-                    state_or_province: France
-                  - id: 29
-                    address1: 5555 Hermann Park Dr
-                    address2: ''
-                    address_type: residential
-                    city: Houston
-                    company: ''
-                    country: United States
-                    country_code: US
-                    customer_id: 20
-                    first_name: Alice
-                    last_name: Golightly
-                    phone: '8901234564'
-                    postal_code: '77030'
-                    state_or_province: Texas
-                  - id: 30
-                    address1: 122 First Street
-                    address2: ''
-                    address_type: residential
-                    city: Austin
-                    company: ''
-                    country: United States
-                    country_code: US
-                    customer_id: 11
-                    first_name: Jon
-                    last_name: Doe
-                    phone: '6789012345'
-                    postal_code: '78726'
-                    state_or_province: Texas
-                  - id: 31
-                    address1: 11305 4 Points Drive
-                    address2: ''
-                    address_type: residential
-                    city: Austin
-                    company: ''
-                    country: United States
-                    country_code: US
-                    customer_id: 11
-                    first_name: Testing
-                    last_name: Bigcommerce
-                    phone: '5122134567'
-                    postal_code: '78726'
-                    state_or_province: Texas
-                  - id: 32
-                    address1: 11305 4 Points Drive
-                    address2: ''
-                    address_type: residential
-                    city: Austin
-                    company: ''
-                    country: United States
-                    country_code: US
-                    customer_id: 20
-                    first_name: Testing
-                    last_name: Bigcommerce
-                    phone: '1234567890'
-                    postal_code: '78726'
-                    state_or_province: Texas
-                  - id: 33
-                    address1: 161 Sajik-ro
-                    address2: ''
-                    address_type: residential
-                    city: Seoul
-                    company: ''
-                    country: 'Korea, Republic of'
-                    country_code: KR
-                    customer_id: 15
-                    first_name: Patricia
-                    last_name: Moriarty
-                    phone: '5121234567'
-                    postal_code: Jongno-gu
-                    state_or_province: Sejongno
-                  - id: 34
-                    address1: 161 Sajik-ro
-                    address2: ''
-                    address_type: residential
-                    city: Seoul
-                    company: ''
-                    country: 'Korea, Republic of'
-                    country_code: KR
-                    customer_id: 15
-                    first_name: Patricia
-                    last_name: Moriarty
-                    phone: '5121234567'
-                    postal_code: Jongno-gu
-                    state_or_province: Sejongno
-                  - id: 38
-                    address1: 'Bennelong Point '
-                    address2: ''
-                    address_type: commercial
-                    city: Sydney
-                    company: ''
-                    country: Australia
-                    country_code: AU
-                    customer_id: 23
+                    customer_id: 1
                     first_name: John
+                    id: 18
                     last_name: Doe
-                    phone: '1234567890'
-                    postal_code: '2000'
-                    state_or_province: New South Wales
-                  - id: 39
-                    address1: 111 E West Street
-                    address2: '654'
-                    address_type: residential
-                    city: Akron
-                    company: ''
-                    country: United States
-                    country_code: US
-                    customer_id: 23
-                    first_name: John
-                    last_name: Doe
-                    phone: '1234567890'
-                    postal_code: '44325'
-                    state_or_province: Ohio
+                    phone: '15551234567'
+                    postal_code: '78759'
+                    state_or_province: Texas
                 meta:
                   pagination:
-                    total: 14
-                    count: 14
+                    total: 1
+                    count: 1
                     per_page: 50
                     current_page: 1
                     total_pages: 1
+    AddressCollectionResponsePostPut:
+      description: ''
+      content:
+        application/json:
+          schema:
+            title: AddressCollectionResponse
+            description: Response payload for the BigCommerce API.
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  title: Address
+                  type: object
+                  properties:
+                    address1:
+                      description: The address 1 line.
+                      type: string
+                    address2:
+                      description: The address 2 line.
+                      type: string
+                    address_type:
+                      title: Address Type
+                      description: The address type. Residential or Commercial
+                      example: residential
+                      type: string
+                      enum:
+                        - residential
+                        - commercial
+                    city:
+                      description: The city of the customer address.
+                      type: string
+                      minLength: 0
+                      maxLength: 100
+                    company:
+                      description: The company of the customer address.
+                      type: string
+                      minLength: 0
+                      maxLength: 255
+                    country:
+                      description: The country name of the customer address.
+                      type: string
+                    country_code:
+                      description: The country code of the customer address.
+                      type: string
+                      minLength: 2
+                      maxLength: 2
+                    customer_id:
+                      description: The customer ID.
+                      type: integer
+                      format: int32
+                    first_name:
+                      description: The first name of the customer address.
+                      type: string
+                      minLength: 1
+                      maxLength: 255
+                    id:
+                      description: The unique numeric ID of the address.
+                      type: integer
+                      format: int32
+                    last_name:
+                      description: The last name of the customer address.
+                      type: string
+                      minLength: 1
+                      maxLength: 255
+                    phone:
+                      description: The phone number of the customer address.
+                      type: string
+                      minLength: 0
+                      maxLength: 50
+                    postal_code:
+                      description: The postal code of the customer address.
+                      type: string
+                      minLength: 0
+                      maxLength: 30
+                    state_or_province:
+                      description: The state or province name
+                      type: string
+                      minLength: 0
+                      maxLength: 100
+                    form_fields:
+                      description: Array of form fields. Controlled by `formfields` parameter.
+                      type: array
+                      items:
+                        oneOf:
+                          - allOf:
+                              - type: object
+                                title: Form Field Value Base
+                              - type: object
+                          - allOf:
+                              - type: object
+                                title: Form Field Value Base
+                              - type: object
+                        title: 'Form Field Value '
+              meta:
+                type: object
+          examples:
+            response:
+              value:
+                data:
+                  - address1: 123 Example Street
+                    address2: Building 4
+                    address_type: residential
+                    city: Austin
+                    company: BigCommerce
+                    country: United States
+                    country_code: US
+                    customer_id: 1
+                    first_name: John
+                    id: 18
+                    last_name: Doe
+                    phone: '15551234567'
+                    postal_code: '78759'
+                    state_or_province: Texas
+                meta: {}
     CustomerAttributeValueCollectionResponse:
       description: ''
       content:
@@ -3222,67 +3073,74 @@ components:
           format: int32
           example: 1
       required:
-        - first_name
-        - last_name
-        - address1
-        - city
-        - state_or_province
-        - postal_code
-        - country_code
         - customer_id
         - id
+      x-examples:
+        example-1:
+          value:
+            - customer_id: 1
+              id: 18
+              first_name: sam
     address_Post:
       title: address_Post
       type: object
       properties:
         first_name:
+          type: string
           description: The first name of the customer address.
-          type: string
           minLength: 1
           maxLength: 255
+          example: John
         last_name:
-          description: The last name of the customer address.
           type: string
+          description: The last name of the customer address.
           minLength: 1
           maxLength: 255
+          example: Doe
         company:
-          description: The company of the customer address.
           type: string
+          description: The company of the customer address.
           minLength: 0
           maxLength: 255
+          example: BigCommerce
         address1:
+          type: string
           description: The address 1 line.
-          type: string
+          example: 123 Example Street
         address2:
+          type: string
           description: The address 2 line.
-          type: string
+          example: Building 4
         city:
-          description: The city of the customer address.
           type: string
+          description: The city of the customer address.
           minLength: 0
           maxLength: 100
+          example: Austin
         state_or_province:
-          description: The state or province name
           type: string
-          example: New South Wales
+          description: The state or province name spelled out in full. State or province codes not accepted.
+          example: Texas
           minLength: 0
           maxLength: 100
         postal_code:
-          description: The postal code of the customer address.
           type: string
+          description: The postal code of the customer address.
           minLength: 0
           maxLength: 30
+          example: '78759'
         country_code:
-          description: The country code of the customer address.
           type: string
-          example: AU
+          description: The country code of the customer address.
+          example: US
           minLength: 2
           maxLength: 2
         phone:
-          description: The phone number of the customer address.
           type: string
+          description: The phone number of the customer address.
           minLength: 0
           maxLength: 50
+          example: '15551234567'
         address_type:
           title: Address Type
           description: The address type. Residential or Commercial
@@ -3305,6 +3163,21 @@ components:
         - postal_code
         - country_code
         - customer_id
+      x-examples:
+        Example:
+          value:
+            first_name: John
+            last_name: Doe
+            company: BigCommerce
+            address1: 123 Example Street
+            address2: Building 4
+            city: Austin
+            state_or_province: Texas
+            postal_code: '78759'
+            country_code: US
+            phone: '15551234567'
+            address_type: residential
+            customer_id: 1
     customerAddresses_Base:
       title: customerAddresses_Base
       example:


### PR DESCRIPTION
[DEVDOCS-3011](https://jira.bigcommerce.com/browse/DEVDOCS-3011)

- Add a note to POST customers/addresses that body does not accept state or province codes
- update values in example to US address and fill in missing fields
- change the order of properties in 200 response to match the actual response format
- shorten example response body to only one customer instead of 5+
- remove required fields from POST description since info is also in the schema
- remove `required` flag from shared example since it doesn't apply
- create another shared response for customer address POST and PUT without meta, since that info is only present in GET responses