### PR TITLE
DEVDOCS-3540: Corrected product option value type from single to array

### DIFF
--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -18091,7 +18091,9 @@ definitions:
         example: 1
         description: 'Order in which the option is displayed on the storefront. '
       option_values:
-        $ref: '#/definitions/productOptionOptionValue_Full'
+        type: array
+        items: 
+          $ref: '#/definitions/productOptionOptionValue_Full'
   productOption_Full:
     allOf:
       - $ref: '#/definitions/productOption_Base'


### PR DESCRIPTION
The `option_values` property is declared as being a single object, but in reality the API returns an array of option values.

This PR corrects that.