### PR TITLE
DEVDOCS-3598: docs(checkout): CHECKOUT-6388 Add Address field as an alias to ShippingAddress in the Consignment API Request

### DIFF
--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+swagger: '3.0'
 info:
   version: ''
   title: Storefront Checkouts
@@ -1187,7 +1187,7 @@ paths:
           description: Unable to determine if provided email is associated with an account. The customer must sign-in.
   '/checkouts/{checkoutId}/consignments':
     post:
-      description: "Adds a new *Consignment* to *Checkout*.\n\nThere are two steps to add a new shipping address and shipping options with line items. \n1. Add a new Consignment to Checkout.\n* \tSend a POST to Consignments with each shipping address and line items IDs. Each address can have its own line item IDs.\n* \tAs part of the request URL make sure to add `include=consignments.availableShippingOptions` to return the available shipping options based on line items and shipping locations. This will return `availableShippingOptions` in the response.\n2. [Update the Consignment](/api-reference/cart-checkout/storefront-checkout-api/checkout-consignments/checkoutsconsignmentsbycheckoutidandconsignmentidput) with Shipping Options.\n\n**Required Query**\n* consignments.availableShippingOptions\n\n**Required Fields**\n* shipping_address\n* line_items\n\nTo learn more about creating a Checkout Consignment see [Working with the Fetch API](/api-docs/cart-and-checkout/working-sf-apis).\n\n<!-- theme: info --> \n\n> #### Note\n> The Send a Test Request feature is not currently supported for this endpoint."
+      description: "Adds a new *Consignment* to *Checkout*.\n\nThere are two steps to add a new shipping address and shipping options with line items. \n1. Add a new Consignment to Checkout.\n* \tSend a POST to Consignments with each shipping address and line items IDs. Each address can have its own line item IDs.\n* \tAs part of the request URL make sure to add `include=consignments.availableShippingOptions` to return the available shipping options based on line items and shipping locations. This will return `availableShippingOptions` in the response.\n2. [Update the Consignment](/api-reference/cart-checkout/storefront-checkout-api/checkout-consignments/checkoutsconsignmentsbycheckoutidandconsignmentidput) with Shipping Options.\n\n**Required Query**\n* consignments.availableShippingOptions\n\n**Required Fields**\n* address\n* line_items\n\nTo learn more about creating a Checkout Consignment see [Working with the Fetch API](/api-docs/cart-and-checkout/working-sf-apis).\n\n<!-- theme: info --> \n\n> #### Note\n> The Send a Test Request feature is not currently supported for this endpoint."
       summary: Create a Consignment
       tags:
         - Checkout Consignments
@@ -1210,7 +1210,7 @@ paths:
               $ref: '#/definitions/CreateConsignmentRequest'
           x-examples:
             application/json:
-              - shippingAddress:
+              - address:
                   firstName: Jane
                   lastName: Doe
                   email: janedoe@example.com
@@ -1227,7 +1227,7 @@ paths:
                 lineItems:
                   - itemId: 69791a88-85c9-4c19-8042-e537621e8a55
                     quantity: 2
-              - shippingAddress:
+              - address:
                   firstName: John
                   lastName: Doe
                   email: johnedoe@example.com
@@ -1365,7 +1365,7 @@ paths:
               customerMessage: ''
   '/checkouts/{checkoutId}/consignments/{consignmentId}':
     put:
-      description: "Updates an existing consignment. Shipping address, line item IDs or the shipping option ID can be updated using this endpoint.\n\nThere are two steps to add a new shipping address and shipping options with line items. \n1. Add a new Consignment to Checkout.\n2. Update the Consignment with Shipping Options.\n* \t Update each *Consignment* `shippingOptionId` (shipping address and line items) with the `availableShippingOption > id` from Step One. \n\n**Required Fields**\n* shippingOptionId\n\nTo learn more about creating a Checkout Consignment see [Working with the Fetch API](/api-docs/cart-and-checkout/working-sf-apis).\n\n<!-- theme: info --> \n\n> #### Note\n> * You cannot pass both a `shippingAddress` and `shippingOptionId` because the shipping option may not be able to be applied to the given address \n> * The Send a Test Request feature is not currently supported for this endpoint."
+      description: "Updates an existing consignment. Shipping address, line item IDs or the shipping option ID can be updated using this endpoint.\n\nThere are two steps to add a new shipping address and shipping options with line items. \n1. Add a new Consignment to Checkout.\n2. Update the Consignment with Shipping Options.\n* \t Update each *Consignment* `shippingOptionId` (shipping address and line items) with the `availableShippingOption > id` from Step One. \n\n**Required Fields**\n* shippingOptionId\n\nTo learn more about creating a Checkout Consignment see [Working with the Fetch API](/api-docs/cart-and-checkout/working-sf-apis).\n\n<!-- theme: info --> \n\n> #### Note\n> * You cannot pass both a `address` and `shippingOptionId` because the shipping option may not be able to be applied to the given address \n> * The Send a Test Request feature is not currently supported for this endpoint."
       tags:
         - Checkout Consignments
       operationId: CheckoutsConsignmentsByCheckoutIdAndConsignmentIdPut
@@ -3431,6 +3431,62 @@ definitions:
     type: object
     properties:
       shippingAddress:
+        deprecated: true
+        title: Address Properties
+        type: object
+        properties:
+          firstName:
+            description: ''
+            type: string
+          lastName:
+            description: ''
+            type: string
+          email:
+            description: ''
+            type: string
+          company:
+            description: ''
+            type: string
+          address1:
+            description: ''
+            type: string
+          address2:
+            description: ''
+            type: string
+          city:
+            description: ''
+            type: string
+          stateOrProvince:
+            description: Represents state or province.
+            type: string
+          stateOrProvinceCode:
+            description: ''
+            type: string
+          countryCode:
+            description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
+            type: string
+          postalCode:
+            description: ''
+            type: string
+          phone:
+            description: ''
+            type: string
+            pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
+          customFields:
+            type: array
+            items:
+              type: object
+              properties:
+                fieldId:
+                  type: string
+                fieldValue:
+                  type: string
+          shouldSaveAddress:
+            description: Indicates if we should add this address to the customer address book.
+            type: boolean
+        required:
+          - countryCode
+      address:
         title: Address Properties
         type: object
         properties:
@@ -3522,10 +3578,66 @@ definitions:
     x-internal: true
   NewUpdateConsignment:
     title: Update Consignment Request
-    description: 'One or more of these three fields are mandatory. Shipping address and line items can be updated in one request. Shipping option ID has to be updated in a separate request, since changing the address or line items can invalidate the previously available shipping options.'
+    description: 'One or more of these three fields are mandatory. Address and line items can be updated in one request. Shipping option ID has to be updated in a separate request, since changing the address or line items can invalidate the previously available shipping options.'
     type: object
     properties:
       shippingAddress:
+        deprecated: true
+        title: Address Properties
+        type: object
+        properties:
+          firstName:
+            description: ''
+            type: string
+          lastName:
+            description: ''
+            type: string
+          email:
+            description: ''
+            type: string
+          company:
+            description: ''
+            type: string
+          address1:
+            description: ''
+            type: string
+          address2:
+            description: ''
+            type: string
+          city:
+            description: ''
+            type: string
+          stateOrProvince:
+            description: Represents state or province.
+            type: string
+          stateOrProvinceCode:
+            description: ''
+            type: string
+          countryCode:
+            description: 'ISO 3166-1 alpha-2 country code. (See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)'
+            type: string
+          postalCode:
+            description: ''
+            type: string
+          phone:
+            description: ''
+            type: string
+            pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
+          customFields:
+            type: array
+            items:
+              type: object
+              properties:
+                fieldId:
+                  type: string
+                fieldValue:
+                  type: string
+          shouldSaveAddress:
+            description: Indicates if we should add this address to the customer address book.
+            type: boolean
+        required:
+          - countryCode
+      address:
         title: Address Properties
         type: object
         properties:

--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+swagger: '3.0'
 info:
   version: '3.0'
   title: Checkouts
@@ -284,7 +284,7 @@ paths:
 
         For more information about working with consignments, see [Checkout consignment](/api-docs/checkouts/checkout-consignment).  
 
-        Though the only required `shipping_address` properties to create a consignment are `email` and `country_code`, to successfully [create an order](/api-reference/store-management/checkouts/checkout-orders/createanorder) the `shipping_address` requires the following properties:
+        Though the only required `address` properties to create a consignment are `email` and `country_code`, to successfully [create an order](/api-reference/store-management/checkouts/checkout-orders/createanorder) the `address` requires the following properties:
         * `first_name`
         * `last_name`
         * `address1`
@@ -293,7 +293,7 @@ paths:
         * `email`
         * `country_code`
 
-        Depending on the country, the following `shipping_address` properties can also be required:
+        Depending on the country, the following `address` properties can also be required:
 
         * `postal_code`
         * `state_or_province`
@@ -327,7 +327,7 @@ paths:
             $ref: '#/definitions/CreateConsignmentRequest'
           x-examples:
             application/json:
-              - shipping_address:
+              - address:
                   email: jane2@example.com
                   country_code: US
                   first_name: BigCommerce
@@ -344,7 +344,7 @@ paths:
                 line_items:
                   - item_id: 27556eb3-6537-4d08-b75e-1ac32d80934b
                     quantity: 1
-              - shipping_address:
+              - address:
                   email: testing@example.com
                   country_code: US
                   first_name: Testing
@@ -394,9 +394,9 @@ paths:
   'stores/{store_hash}/v3/checkouts/{checkoutId}/consignments/{consignmentId}':
     put:
       description: |-
-        Updates an existing consignment. Shipping address, line item IDs or the shipping option ID can be updated using this endpoint.
+        Updates an existing consignment. Address, line item IDs or the shipping option ID can be updated using this endpoint.
 
-        There are two steps to add a new shipping address and shipping options with line items. 
+        There are two steps to add a new address and shipping options with line items. 
         1. Add a new [consignment](/api-reference/store-management/checkouts/checkout-consignments/checkoutsconsignmentsbycheckoutidpost) to a checkout.
         2. Assign a shipping option to the new consignment by sending a `PUT` request to update the consignment's `shipping_option_id` with a returned value from `data.consignments[N].available_shipping_option[N].id` in step one.
       summary: Update Checkout Consignment
@@ -435,7 +435,7 @@ paths:
             Updating shipping optionID:
               shipping_option_id: 9241669174884c2f2e83b3adabf03f83
             Updating shipping address:
-              shipping_address:
+              address:
                 email: jane2@example.com
                 country_code: US
                 first_name: Testing
@@ -1477,6 +1477,64 @@ definitions:
     type: object
     properties:
       shipping_address:
+        deprecated: true
+        title: Address Properties
+        type: object
+        properties:
+          first_name:
+            description: ''
+            type: string
+          last_name:
+            description: ''
+            type: string
+          email:
+            type: string
+            description: ''
+          company:
+            description: ''
+            type: string
+          address1:
+            description: ''
+            type: string
+          address2:
+            description: ''
+            type: string
+          city:
+            description: ''
+            type: string
+          state_or_province:
+            description: Represents state or province.
+            type: string
+          state_or_province_code:
+            description: ''
+            type: string
+          country_code:
+            type: string
+            description: ''
+          postal_code:
+            description: ''
+            type: string
+          phone:
+            description: ''
+            type: string
+            pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
+          custom_fields:
+            description: 'You can retreive custom fields from the [Get Form Fields](/api-reference/storefront/form-fields/form-fields/getformfields) endpoint.'
+            type: array
+            items:
+              title: Custom Field
+              type: object
+              properties:
+                field_id:
+                  description: ''
+                  type: string
+                field_value:
+                  description: 'This can also be an array for fields that need to support list of values (e.g., a set of check boxes.)'
+                  type: string
+        required:
+          - email
+          - country_code
+      address:
         title: Address Properties
         type: object
         properties:
@@ -1553,10 +1611,68 @@ definitions:
     x-internal: true
   UpdateConsignmentRequest:
     title: Update Consignment Request
-    description: One or more of these three fields are mandatory. `shipping_address` and `line_items` can be updated in one request. `shipping_option_id` has to be updated in a separate request since changing the address or line items can invalidate the previously available shipping options.
+    description: One or more of these three fields are mandatory. `address` and `line_items` can be updated in one request. `shipping_option_id` has to be updated in a separate request since changing the address or line items can invalidate the previously available shipping options.
     type: object
     properties:
       shipping_address:
+        deprecated: true
+        title: Address Properties
+        type: object
+        properties:
+          first_name:
+            description: ''
+            type: string
+          last_name:
+            description: ''
+            type: string
+          email:
+            type: string
+            description: ''
+          company:
+            description: ''
+            type: string
+          address1:
+            description: ''
+            type: string
+          address2:
+            description: ''
+            type: string
+          city:
+            description: ''
+            type: string
+          state_or_province:
+            description: Represents state or province.
+            type: string
+          state_or_province_code:
+            description: ''
+            type: string
+          country_code:
+            type: string
+            description: ''
+          postal_code:
+            description: ''
+            type: string
+          phone:
+            description: ''
+            type: string
+            pattern: '^\+?[1-9]\d{1,14}(x\d{1-5})?$'
+          custom_fields:
+            description: ''
+            type: array
+            items:
+              title: Custom Field
+              type: object
+              properties:
+                field_id:
+                  description: ''
+                  type: string
+                field_value:
+                  description: 'This can also be an array for fields that need to support list of values (e.g., a set of check boxes.)'
+                  type: string
+        required:
+          - email
+          - country_code
+      address:
         title: Address Properties
         type: object
         properties:


### PR DESCRIPTION
## What?
Creating an alias to shippingAddress called Address in both Storefront and S2S Api request and deprecate (do not delete) the shippingAddress field.

## Why?
As discussed, it would make more sense to return an Address field in the consignment api so it works for Pickup and Shipping - Given this change, we think it also makes sense to update the request to match the response.

## Testing / Proof
![image](https://user-images.githubusercontent.com/84553389/156257004-c8321349-c1f8-438c-a01d-f2f5d9df8c78.png)
![image](https://user-images.githubusercontent.com/84553389/156257246-dcb11261-4b07-42a7-a08f-37c51b40bd99.png)


## How can this change be undone in case of failure?
Revert

ping @bigcommerce/checkout  @bigcommerce/dev-docs

