### PR TITLE
DEVDOCS-3302?: docs(checkout): CHECKOUT-6553 Add documentation for storefront cart currency endpoint

### DIFF
--- a/reference/carts.sf.yml
+++ b/reference/carts.sf.yml
@@ -250,6 +250,45 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/deleteCartsItems'
+  '/cart/{cartId}/currency':
+    post:
+      tags:
+        - Cart Currency
+      summary: Update Cart currency
+      description: |-
+        Update currency of the *Cart*. 
+        Promotions and gift certificates that don't apply to the new currency will be removed from your cart.
+        The cart currency would not be able to update if the draft order cart or the cart contains manual discount.
+
+        <!-- theme: info -->
+        > #### Note
+        > The Send a Test Request feature is not currently supported for this endpoint.
+      operationId: addCartCurrency
+      parameters:
+        - name: cartId
+          in: path
+          description: This cart's unique ID.
+          required: true
+          schema:
+            type: string
+            format: UUID
+      responses:
+        '200':
+          $ref: '#/components/responses/getCarts'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              title: Cart Currency Request Data
+              required:
+                - currencyCode
+              type: object
+              properties:
+                currencyCode:
+                  type: string
+                  description: currency code
+              x-internal: false
+        description: ''
 components:
   schemas:
     responseCartCoupons:


### PR DESCRIPTION
## What?
As above

## Why?
We created a while ago an endpoint `/cart/change-currency` to allow changing the currency of a cart on Storefront. However, we added it as a private endpoint so we didn't add the `storefront` namespace at the time.

Due to feedback from sales engineers and dev doc teams, it turns out developers would like to have public access to this endpoint in order to build custom solutions on the storefront that allows the shopper to change currency. 

In order to make this endpoint publicly available, we need to ensure the URL of the endpoint is consistent with other endpoints.

## Testing / Proof
![image](https://user-images.githubusercontent.com/84553389/161478389-c79cc922-e94d-4a12-9510-4266c3fb3142.png)

## How can this change be undone in case of failure?
Revert

ping @bigcommerce/checkout  @bigcommerce/dev-docs @traci707 

