### PR TITLE
DEVDOCS-3730-removed-keyword-like

### DIFF
--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -18600,10 +18600,6 @@ paths:
           in: query
           schema:
             type: string
-        - name: 'keyword:like'
-          in: query
-          schema:
-            type: string
         - name: is_visible
           in: query
           schema:


### PR DESCRIPTION
# [DEVDOCS-3730](https://jira.bigcommerce.com/browse/DEVDOCS-3730)

## What changed?
Removed keyword:like from Get All Categories endpoint