### PR TITLE
DEVDOCS-3670: broken image on graphql page

### DIFF
--- a/docs/storefront-graphql.md
+++ b/docs/storefront-graphql.md
@@ -49,7 +49,7 @@ You can complete the GraphQL query call with any HTTP library. Use the `data.tok
 
 ```http title="Example GraphQL query" lineNumbers
 POST /graphql
-Authorization: Bearer {{TOKEN}}
+Authorization: Bearer {{JWT}}
 Content-Type: application/json
 
 {

--- a/docs/storefront-graphql.md
+++ b/docs/storefront-graphql.md
@@ -1,22 +1,15 @@
 # GraphQL Storefront API
 
-* **Host**: {$$.env.store_domain}/graphql
-* **Protocols**: `https`
-* **Accepts**: `application/json`
-* **Responds with**: `application/json`
-
-Download Spec: [storefront_tokens.v3.yml](https://bigcommerce.stoplight.io/api/v1/projects/bigcommerce/api-reference/nodes/reference/storefront_tokens.v3.yml?branch=master&amp;deref=all&amp;format=json)
-
 Use GraphQL to query data for headless storefronts and BigCommerce [Stencil](/stencil-docs/getting-started/about-stencil)-powered storefronts.
 
-## GraphQL Playground
+## GraphQL playground
 
 To access the GraphQL Storefront API Playground and documentation, [log in to your store](https://login.bigcommerce.com/deep-links/manage) and navigate to **Advanced Settings** **>** **Storefront API Playground**.
 
 If you don't yet have a store and would like to experiment making queries against a staging site, [visit the Dev Center's GraphQL Playground directly](/graphql-playground).
 
 
-## GraphQL Explorer
+## GraphQL explorer
 
 To explore Storefront nodes in an interactive graph, check out the [GraphQL Explorer](/graphql-explorer).
 
@@ -40,8 +33,6 @@ Accept: application/json
   ]
 }
 ```
-
-[![Open in Request Runner](https://storage.googleapis.com/bigcommerce-production-dev-center/images/Open-Request-Runner.svg)](/api-reference/storefront/graphql-api-tokens/api-token/createtoken#requestrunner)
 
 
 ### Tokens via handlebars
@@ -76,9 +67,7 @@ Accept: application/json
 
 ```
 
-[![Open in Request Runner](/api-reference/store-management/tokens/customer-impersonation-token/createtokenwithcustomerimpersonation#requestrunner)
-
-[Response](/api-reference/store-management/tokens/customer-impersonation-token/createtokenwithcustomerimpersonation#responses):
+**Response:**
 
 ```json
 {

--- a/docs/storefront-graphql.md
+++ b/docs/storefront-graphql.md
@@ -2,14 +2,14 @@
 
 Use GraphQL to query data for headless storefronts and BigCommerce [Stencil](/stencil-docs/getting-started/about-stencil)-powered storefronts.
 
-## GraphQL playground
+## GraphQL Playground
 
 To access the GraphQL Storefront API Playground and documentation, [log in to your store](https://login.bigcommerce.com/deep-links/manage) and navigate to **Advanced Settings** **>** **Storefront API Playground**.
 
 If you don't yet have a store and would like to experiment making queries against a staging site, [visit the Dev Center's GraphQL Playground directly](/graphql-playground).
 
 
-## GraphQL explorer
+## GraphQL Explorer
 
 To explore Storefront nodes in an interactive graph, check out the [GraphQL Explorer](/graphql-explorer).
 

--- a/docs/storefront-graphql.md
+++ b/docs/storefront-graphql.md
@@ -15,11 +15,13 @@ To explore Storefront nodes in an interactive graph, check out the [GraphQL Expl
 
 ## Authentication
 
-### Tokens via API
 
-Create JWT tokens for authenticating cross-origin requests by making a `POST` request to [/v3/storefront/api-token](/api-reference/storefront/graphql-api-tokens/api-token/createtoken).
 
-```http
+### Request tokens with REST API
+
+Create JWT tokens for authenticating cross-origin requests by making a `POST` request to the [Create a token](/api-reference/store-management/tokens/api-token/createtoken) endpoint.
+
+```http title="Example request: Create a token" lineNumbers
 POST https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/storefront/api-token
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -33,28 +35,54 @@ Accept: application/json
   ]
 }
 ```
+&nbsp;
+```json title="Example response: Create a token" lineNumbers
+{
+  "data": {
+    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+  },
+  "meta": {}
+}
+```
+
+You can complete the GraphQL query call with any HTTP library. Use the `data.token` value from the preceding response as the `{{JWT}}` value in the `Authorization: Bearer {{JWT}}` header. 
+
+```http title="Example GraphQL query" lineNumbers
+POST /graphql
+Authorization: Bearer {{TOKEN}}
+Content-Type: application/json
+
+{
+  "query": "{ site { ... } }" //graphql query string
+}
+```
 
 
-### Tokens via handlebars
+### Access tokens using Stencil objects
 
-Client code on BigCommerce [Stencil](/stencil-docs/getting-started/about-stencil)-powered storefronts can be passed a token at render time with the `{{settings.storefront_api.token}}` Handlebars object.
+Client scripts on BigCommerce [Stencil](/stencil-docs/getting-started/about-stencil)-powered storefronts can access a token with the `{{settings.storefront_api.token}}` Handlebars object.
 
-```js
+```handlebars title="Example GraphQL query script with Stencil token" lineNumbers
+<script>
+// nest within any conditional, such as onload
   fetch('/graphql', {
     method: 'POST',
     headers: {
-    'Content-Type': 'application/json',
-    'Authorization': 'Bearer {{settings.storefront_api.token}}'
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer {{settings.storefront_api.token}}'
     },
-    body: JSON.stringify({ query: '{ site { ... } }' }),
-  });
+    body: JSON.stringify({ query: '{ site { ... } }' }) //graphql query string
+  })
+  .then(data => console.log(data))
+  .catch(error => console.error(error));
+</script>
 ```
 
 ### Customer impersonation tokens
 
-It's also possible to generate tokens for use in server-to-server interactions with a trusted consumer. To [create a customer impersonation token](/api-reference/store-management/tokens/customer-impersonation-token/createtokenwithcustomerimpersonation), send a `POST` request to `/v3/storefront/api-token-customer-impersonation`.
+It's also possible to generate tokens for use in server-to-server interactions with a trusted consumer. Make a `POST` request to the [Create a customer impersonation token](/api-reference/store-management/tokens/customer-impersonation-token/createtokenwithcustomerimpersonation) endpoint.
 
-```http
+```http title="Example request: Create a customer impersonation token" lineNumbers
 POST https://api.bigcommerce.com/stores/{{STORE_HASH}}/v3/storefront/api-token-customer-impersonation
 X-Auth-Token: {{ACCESS_TOKEN}}
 Content-Type: application/json
@@ -66,15 +94,12 @@ Accept: application/json
 }
 
 ```
-
-**Response:**
-
-```json
+&nbsp;
+```json title="Example response: Create a customer impersonation token" lineNumbers
 {
-  "data":
-  {
+  "data": {
     "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-  }
+  },
   "meta": {}
 }
 ```
@@ -84,14 +109,13 @@ Accept: application/json
 
 If you're using the Storefront API from a browser (for example, on top of your Stencil storefront) you can use the Customer Login mutation to log in a customer account with an email address and password (for server-side integrations, consider a customer impersonation token instead). This will set a session cookie in the browser which will authenticate the customer account on future requests:
 
-```js
+```graphql title="Customer login mutation" lineNumbers
 mutation Login($email: String!, $pass: String!) {
   login(email: $email, password: $pass) {
     result
   }
 }
 ```
-
 
 As a best practice, you should inject the password using GraphQL query variables. This prevents the password from being exposed in the query itself. In the [GraphQL Playground](/graphql-playground), you can set the variables for the request. [Learn more about GraphQL Storefront API Authentication](/api-docs/storefront/graphql/graphql-storefront-api-overview#authentication).
 


### PR DESCRIPTION
# [DEVDOCS-3670](https://jira.bigcommerce.com/browse/DEVDOCS-3670)

## What changed?
* Remove request runner buttons/graphics
* Remove duplicate API info in intro