### PR TITLE
DEVDOCS-3884-increase-limits-to-250

### DIFF
--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -3816,7 +3816,7 @@ paths:
         **Read-Only Fields**
         * id
 
-        **Note:** The max number of metafields allowed on each product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
+        **Note:** The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
       operationId: createVariantMetafield
       parameters:
         - name: product_id
@@ -11986,7 +11986,7 @@ paths:
         **Read-Only Fields**
         * id
 
-        **Note:** The max number of metafields allowed on each product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
+        **Note:** The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
       operationId: createProductMetafield
       parameters:
         - name: product_id
@@ -14735,7 +14735,7 @@ paths:
         **Read-Only Fields**
         - id
 
-        **Note:** The max number of metafields allowed on each product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
+        **Note:** The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
       operationId: createCategoryMetafield
       parameters:
         - name: category_id
@@ -16804,7 +16804,7 @@ paths:
         **Read-Only Fields**
         - id
 
-        **Note:** The max number of metafields allowed on each product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
+        **Note:** The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
       operationId: createBrandMetafield
       parameters:
         - name: brand_id
@@ -17225,7 +17225,7 @@ paths:
       tags:
         - Brand Metafields
       summary: Update a Brand Metafield
-      description: "Updates a *Brand Metafield*.\n\n**Required Fields**  \n* none\n\n**Read-Only Fields**\n* id\n* These fields can only be modified by the app (API credentials) that created the metafield:\n\t* namespace\n\t* key\n\t* permission_set\n\n**Usage Notes**\n* Attempting to modify `namespace`, `key`, and `permission_set` fields using a client ID different from the one used to create those metafields will result in a 403 error message.\n* The max number of metafields allowed on each product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center."
+      description: "Updates a *Brand Metafield*.\n\n**Required Fields**  \n* none\n\n**Read-Only Fields**\n* id\n* These fields can only be modified by the app (API credentials) that created the metafield:\n\t* namespace\n\t* key\n\t* permission_set\n\n**Usage Notes**\n* Attempting to modify `namespace`, `key`, and `permission_set` fields using a client ID different from the one used to create those metafields will result in a 403 error message.\n* The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center."
       operationId: updateBrandMetafield
       parameters:
         - name: metafield_id

--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -14,6 +14,7 @@ tags:
   - name: Metafields
   - name: Payment Actions
   - name: Transactions
+  - name: Order Settings
 paths:
   '/stores/{store_hash}/v3/orders/{order_id}/payment_actions/capture':
     post:
@@ -782,7 +783,7 @@ paths:
       description: |
         Gets a `Metafield` object list, by `order_id`.
 
-        The maxiumum number of metafields is 50 per order.
+        The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID.
       operationId: getOrderMetafieldsByOrderId
       parameters:
         - $ref: '#/components/parameters/PageParam'
@@ -812,7 +813,7 @@ paths:
       description: |-
         Creates an order `Metafield`.
 
-        The maxiumum number of metafields is 50 per order.
+        The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID.
       operationId: createOrderMetafield
       requestBody:
         content:
@@ -894,7 +895,7 @@ paths:
       description: |-
         Updates a `Metafield` object.
 
-        The maxiumum number of metafields is 50 per order.
+        The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID.
       operationId: updateOrderMetafield
       requestBody:
         content:
@@ -934,6 +935,7 @@ paths:
     get:
       summary: Get Global Order Settings
       description: Returns global order settings.
+      operationId: GetGlobalOrderSettings
       tags:
         - Order Settings
       responses:
@@ -955,6 +957,7 @@ paths:
     put:
       summary: Update Global Order Settings
       description: Updates global order settings.
+      operationId: UpdateGlobalOrderSettings
       tags:
         - Order Settings
       requestBody:
@@ -998,6 +1001,7 @@ paths:
     get:
       summary: Get Channel Order Settings
       description: Returns order settings for a specific channel.
+      operationId: GetChannelOrderSettings
       tags:
         - Order Settings
       parameters:
@@ -1030,6 +1034,7 @@ paths:
         Updates order settings for a specific channel. 
 
          **Note:** You must override both notifications `email_addresses` or neither, i.e. either both notification `email_addresses` are an array of valid email addresses, or both `email_addresses` must be null. You may not have one set to an array of addesses and the other set to `null`.
+      operationId: UpdateChannelOrderSettings
       tags:
         - Order Settings
       parameters:


### PR DESCRIPTION
# [DEVDOCS-3884](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3884)

## What changed?
 Increased metafields limits to 250 for the other resources. See the list in the JIRA ticket.
Resolved file errors

