### PR TITLE
Devdocs 4059 update Oauth scope

### DIFF
--- a/reference/redirects.v3.yml
+++ b/reference/redirects.v3.yml
@@ -30,7 +30,7 @@ securityDefinitions:
       ### OAuth Scopes
       |  **UI Name** | **Permission** | **Parameter** |
       | --- | --- | --- |
-      |  Carts | modify | `store_cart` |
+      |  Content | modify | `store_cart` |
       |  Carts | read-only | `store_cart_read_only` |
 
       ### Headers

--- a/reference/redirects.v3.yml
+++ b/reference/redirects.v3.yml
@@ -30,8 +30,8 @@ securityDefinitions:
       ### OAuth Scopes
       |  **UI Name** | **Permission** | **Parameter** |
       | --- | --- | --- |
-      |  Content | modify | `store_cart` |
-      |  Carts | read-only | `store_cart_read_only` |
+      |  Content | modify | `store_v2_content` |
+      |  Content | read-only | `store_v2_content_read_only` |
 
       ### Headers
 


### PR DESCRIPTION
# [DEVDOCS-4059](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4059)

## What changed?
The OAuth scopes for the Redirects API was incorrect and giving a 404 error. When changed to Content it worked. You can see the ticket for screenshots.
