### PR TITLE
DEVDOCS-4325: add external_order_id to v2/orders

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -3085,7 +3085,7 @@ components:
               external_order_id:
                 type: string
                 example: 'external-order-id'
-                description: The external id of the order
+                description: The external id of the order.
   requestBodies: null
   securitySchemes:
     X-Auth-Token:
@@ -4227,7 +4227,7 @@ components:
         external_order_id:
           type: string
           example: 'external-order-id'
-          description: The external id of the order
+          description: The external id of the order.
         total_ex_tax:
           description: 'Override value for the total, excluding tax. If specified, the field `total_inc_tax` is also required. (Float, Float-As-String, Integer)'
           example: '225.0000'

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -1538,7 +1538,7 @@ components:
                   store_default_to_transactional_exchange_rate: '1.0000000000'
                   custom_status: Awaiting Fulfillment
                   customer_locale: en
-                  external_order_id: ''
+                  external_order_id: 'external-order-id'
     ordersCount_Resp:
       description: Order Countr response collection.
       content:
@@ -1755,7 +1755,7 @@ components:
                 store_default_to_transactional_exchange_rate: '1.0000000000'
                 custom_status: Awaiting Payment
                 customer_locale: en
-                external_order_id: ''
+                external_order_id: 'external-order-id'
               Multiple Items:
                 id: 247
                 customer_id: 11
@@ -1847,7 +1847,7 @@ components:
                 store_default_to_transactional_exchange_rate: 1
                 custom_status: Awaiting Fulfillment
                 customer_locale: en
-                external_order_id: ''
+                external_order_id: 'external-order-id'
     orderCouponsCollection_Resp:
       description: ''
       content:
@@ -2735,7 +2735,7 @@ components:
               external_id: null
               external_merchant_id: null
               custom_status: Awaiting Payment
-              external_order_id: ''
+              external_order_id: 'external-order-id'
             type: object
             properties:
               id:

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -1538,6 +1538,7 @@ components:
                   store_default_to_transactional_exchange_rate: '1.0000000000'
                   custom_status: Awaiting Fulfillment
                   customer_locale: en
+                  external_order_id: ''
     ordersCount_Resp:
       description: Order Countr response collection.
       content:
@@ -1754,6 +1755,7 @@ components:
                 store_default_to_transactional_exchange_rate: '1.0000000000'
                 custom_status: Awaiting Payment
                 customer_locale: en
+                external_order_id: ''
               Multiple Items:
                 id: 247
                 customer_id: 11
@@ -1845,6 +1847,7 @@ components:
                 store_default_to_transactional_exchange_rate: 1
                 custom_status: Awaiting Fulfillment
                 customer_locale: en
+                external_order_id: ''
     orderCouponsCollection_Resp:
       description: ''
       content:
@@ -2732,6 +2735,7 @@ components:
               external_id: null
               external_merchant_id: null
               custom_status: Awaiting Payment
+              external_order_id: ''
             type: object
             properties:
               id:
@@ -3075,9 +3079,13 @@ components:
                   - AvaTaxProvider
                   - ''
               customer_locale:
-                type: 'string,'
+                type: string
                 example: en
                 description: The customer’s locale.
+              external_order_id:
+                type: string
+                example: 'external-order-id'
+                description: The external id of the order
   requestBodies: null
   securitySchemes:
     X-Auth-Token:
@@ -4216,6 +4224,10 @@ components:
           type: string
           example: en
           description: The customer’s locale.
+        external_order_id:
+          type: string
+          example: 'external-order-id'
+          description: The external id of the order
         total_ex_tax:
           description: 'Override value for the total, excluding tax. If specified, the field `total_inc_tax` is also required. (Float, Float-As-String, Integer)'
           example: '225.0000'


### PR DESCRIPTION
# [DEVDOCS-4325](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4325)

## What changed?
* Add `external_order_id` to `v2/orders`

@bigcommerce/orders 
