### PR TITLE
DEVDOCS-4224 add bigcommerce platform to the list of storefront channel types

### DIFF
--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -49,6 +49,7 @@ info:
     | `etsy`            | `marketplace`             |
     | `wish`            | `marketplace`             |
     | `walmart`         | `marketplace`             |
+    | `bigcommerce`     | `storefront`              |
     | `gatsby`          | `storefront`              |
     | `wordpress`       | `storefront`              |
     | `drupal`          | `storefront`              |


### PR DESCRIPTION
# [DEVDOCS-4224]

## What changed?
* add bigcommerce platform to the list of storefront channel types


[DEVDOCS-4224]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ