### PR TITLE
DEVDOCS-3806: [update] Get transaction orders endpoint

### DIFF
--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -736,7 +736,7 @@ paths:
                         }
                     }
         '503':
-          description: "Every request in the batch failed. The error object describes the failure for each component request."
+          description: Every request in the batch failed. The error object describes the failure for each component request.
           content:
             application/json:
               schema:
@@ -1848,6 +1848,7 @@ components:
                 - amazon
                 - authorizenet
                 - bankdeposit
+                - bigcommerce
                 - braintree
                 - cheque
                 - cod
@@ -1863,7 +1864,7 @@ components:
                 - paypalexpress
                 - paypalpaymentsprous
                 - paypalpaymentsprouk
-                - plugnpay
+                - plugnplay
                 - qbmsv2
                 - securenet
                 - square
@@ -2004,15 +2005,6 @@ components:
                   type: number
                   format: float
                   example: 35.42
-                status:
-                  description: |
-                    The status of a gift certificate: `active` - gift certificate is active; `pending` - gift certificate purchase is pending; `disabled` - gift certificate is disabled; `expired` - gift certificate is expired.
-                  type: string
-                  enum:
-                    - active
-                    - pending
-                    - disabled
-                    - expired
             store_credit:
               type: object
               description: |
@@ -2310,11 +2302,11 @@ components:
           example: 1
         items:
           type: array
-          items:  
+          items:
             $ref: '#/components/schemas/ItemsRefund'
       required:
-         - order_id
-         - items
+        - order_id
+        - items
     RefundQuote_Full:
       type: object
       title: RefundQuote_Full


### PR DESCRIPTION
# [DEVDOCS-3806](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3806)

## What changed?
* Remove `giftcertificate` and `storecredit` values from gateway
* Add `bigcommerce` as a gateway value
* Remove `status` field from gift_certificate object


[DEVDOCS-3806]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-3806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ