### PR TITLE
DEVDOCS-4483: [update description] Tax Provider, ItemRequest item_code

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -856,7 +856,7 @@ components:
           description: A unique identifier for this item used to map responses back to the corresponding item on the order.
         item_code:
           type: string
-          description: 'The SKU/UPC of the item, if available.'
+          description: 'The UPC/SKU of the item. The UPC value will be used when both UPC and SKU values are available on the item.'
         name:
           type: string
           description: A display name for this item.


### PR DESCRIPTION
# [DEVDOCS-4483]

## What changed?
* Describing the logic around UPC vs SKU usage within the `ItemRequest` **item_code** field so that we have a higher level of self-service.

## Anything else?
- A straight forward description update.
- Relates to feedback from a tax provider partner.


[DEVDOCS-4483]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ping @bc-andreadao @bigcommerce/shipping 