### PR TITLE
DEVDOCS-4488: Tax Provider, include tax properties on ItemRequest

### DIFF
--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -885,6 +885,11 @@ components:
           type: boolean
           description: 'Flag whether or not this item is always tax-exempt. For example, gift certificate purchases and order-level refunds are tax-exempt. Tax-exempt items are included in the request for auditing purposes.'
           default: false
+        tax_properties:
+          type: array
+          description: Merchants may opt to include additional properties that a tax provider can choose to support, factoring these values into tax calculation.
+          items:
+            $ref: '#/components/schemas/request-item-tax-property'
         type:
           type: string
           description: |-


### PR DESCRIPTION
# [DEVDOCS-4488]

## What changed?
* Adding a missing description to ItemRequest.

## Anything else?
* Since we have both ItemRequest and ItemRequestWrapping we need to make sure to remember to update both/keep both descriptions in sync.

ping @bigcommerce/shipping @bc-andreadao 


[DEVDOCS-4488]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ