### PR TITLE
DEVDOCS-4495 Orders V2 add wrapping_id to orderCatalogProductPost

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -4632,14 +4632,20 @@ components:
         variant_id:
           type: integer
           description: '""'
+        wrapping_id:
+          type: integer
+          description: 'ID of gift wrapping to be used for this product. When provided, `wrapping_cost_ex_tax` and `wrapping_cost_inc_tax` are required. When updating an order product line item, if `wrapping_id` is set to `0` and no other wrapping fields are provided, wrapping will be removed from the order product'
         wrapping_name:
           type: string
+          description: 'If `wrapping_id` is provided, this will automatically be populated with the name of the gift wrapping to be used'
         wrapping_message:
           type: string
         wrapping_cost_ex_tax:
           type: number
+          description: 'When provided, this value should be equal to `wrapping_cost_ex_tax` times quantity to accurately reflect wrapping cost per unit'
         wrapping_cost_inc_tax:
           type: number
+          description: 'When provided, this value should be equal to `wrapping_cost_inc_tax` times quantity to accurately reflect wrapping cost per unit'
       x-internal: false
     orderCustomProduct_Post:
       title: orderCustomProduct_Post
@@ -4714,8 +4720,8 @@ components:
               type: array
               items:
                 anyOf:
-                  - $ref: '#/components/schemas/orderCustomProduct_Post'
                   - $ref: '#/components/schemas/orderCatalogProduct_Post'
+                  - $ref: '#/components/schemas/orderCustomProduct_Post'
             shipping_addresses:
               type: array
               items:


### PR DESCRIPTION
# [DEVDOCS-4495]

## What changed?
* Added `wrapping_id` to `orderCatalogProduct_Post` for v2 Orders
* Added descriptions to related wrapping fields to describe how to use them with `wrapping_id`

## Anything else?
ORDERS ticket: https://bigcommercecloud.atlassian.net/browse/ORDERS-4969

### Relevant technical details
* Added `wrapping_id` field to POST and PUT requests to `v2/orders` (currently only for Catalog Products). This allows existing gift wrapping options to be added to an order product when creating or updating via the v2 Orders API, bringing it closer to feature parity with CP.
* This is an additive change, so previous gift wrapping behaviour for POST and PUT remains the same and only changes when a request includes the `wrapping_id` field, such as requiring `wrapping_cost_inc_tax` and `wrapping_cost_ex_tax`.
* If a PUT request includes `wrapping_id` as `0` and no other related wrapping fields on an order product, all wrapping details will be removed from that product.
* When setting the `wrapping_cost` fields on an order product, this is the total cost of gift wrapping for that order product. What this means in practice is that if an order product added via the API has a quantity of `2` and a `wrapping_cost` of `1`, when viewed in CP, the gift wrapping is $1.00 in total but seems to be worth $0.50 per unit. This is different to how it looks in Storefront, where if a user adds gift wrapping worth $1.00 to a product with a quantity of `2`, the total gift wrapping cost will be $2.00.


[DEVDOCS-4495]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ