### PR TITLE
DEVDOCS-4528 download consignment support in PUT

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -5059,23 +5059,40 @@ components:
               items:
                 $ref: '#/components/schemas/giftCertificateConsignment_Get'
     digitalConsignment_Post:
-      allOf:
-        - type: object
-          properties:
-            line_items:
-              required: true
-              type: array
-              minItems: 1
-              items:
-                type: array
-                items:
-                  anyOf:
-                    - $ref: '#/components/schemas/orderCatalogProduct_Post'
       x-examples:
-        x-example-1:
+        example-1:
           line_items:
-            - url: https://api.bigcommerce.com/stores/{$$.env.store_hash}/v2/orders/129/products/12
-              resource: /orders/129/products/12
+            - product_id: 11
+              name: Fog Linen Chambray Towel - Beige Stripe
+              name_customer: Fog Linen Chambray Towel - Beige Stripe
+              name_merchant: Towel Type 1
+              product_options:
+                - id: 123
+                  value: string
+                  display_name: couleur
+                  display_name_customer: couleur
+                  display_name_merchant: color
+                  display_value: bleu
+                  display_value_merchant: blue
+                  display_value_customer: bleu
+              quantity: 1
+              price_inc_tax: 10
+              price_ex_tax: 10
+              upc: string
+              variant_id: 11
+              wrapping_name: string
+              wrapping_message: string
+              wrapping_cost_ex_tax: 0
+              wrapping_cost_inc_tax: 0
+      type: object
+      properties:
+        line_items:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/orderCatalogProduct_Post'
+      required:
+        - line_items
     digitalConsignment_Put:
       x-examples:
         example-1:

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -5014,6 +5014,8 @@ components:
                   - $ref: '#/components/schemas/orderCustomProduct_Put'
             shipping_addresses:
               $ref: '#/components/schemas/shippingAddress_Base'
+            consignments:
+              $ref: '#/components/schemas/orderConsignment_Put'
         - $ref: '#/components/schemas/order_Shared'
       x-internal: false
     order_Post:
@@ -5074,6 +5076,45 @@ components:
           line_items:
             - url: https://api.bigcommerce.com/stores/{$$.env.store_hash}/v2/orders/129/products/12
               resource: /orders/129/products/12
+    digitalConsignment_Put:
+      x-examples:
+        example-1:
+          line_items:
+            - id: 12
+              quantity: 2
+            - product_id: 11
+              name: Fog Linen Chambray Towel - Beige Stripe
+              name_customer: Fog Linen Chambray Towel - Beige Stripe
+              name_merchant: Towel Type 1
+              product_options:
+                - id: 111
+                  value: string
+                  display_name: couleur
+                  display_name_customer: couleur
+                  display_name_merchant: color
+                  display_value: bleu
+                  display_value_merchant: blue
+                  display_value_customer: bleu
+              quantity: 1
+              price_inc_tax: 10
+              price_ex_tax: 10
+              upc: string
+              variant_id: 21
+              wrapping_name: string
+              wrapping_message: string
+              wrapping_cost_ex_tax: 0
+              wrapping_cost_inc_tax: 0
+      type: object
+      properties:
+        line_items:
+          type: array
+          minItems: 1
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/orderCatalogProduct_Put'
+              - $ref: '#/components/schemas/orderCatalogProduct_Post'
+      required:
+        - line_items
     shippingConsignment_Post:
       allOf:
         - $ref: '#/components/schemas/shippingConsignment_Base'
@@ -5148,6 +5189,44 @@ components:
           maxItems: 1
           items:
             $ref: '#/components/schemas/digitalConsignment_Post'
+    orderConsignment_Put:
+      title: ''
+      type: object
+      x-examples:
+        Download consignment:
+          downloads:
+            - line_items:
+                - id: 122
+                  quantity: 2
+                - product_id: 11
+                  name: Fog Linen Chambray Towel - Beige Stripe
+                  name_customer: Fog Linen Chambray Towel - Beige Stripe
+                  name_merchant: Towel Type 1
+                  product_options:
+                    - id: 111
+                      value: string
+                      display_name: couleur
+                      display_name_customer: couleur
+                      display_name_merchant: color
+                      display_value: bleu
+                      display_value_merchant: blue
+                      display_value_customer: bleu
+                  quantity: 1
+                  price_inc_tax: 10
+                  price_ex_tax: 10
+                  upc: string
+                  variant_id: 21
+                  wrapping_name: string
+                  wrapping_message: string
+                  wrapping_cost_ex_tax: 0
+                  wrapping_cost_inc_tax: 0
+      properties:
+        downloads:
+          type: array
+          minItems: 0
+          maxItems: 1
+          items:
+            $ref: '#/components/schemas/digitalConsignment_Put'
     orderConsignments_Resource:
       title: orderConsignments_Resource
       description: URL of the shipping consignment for API requests.


### PR DESCRIPTION
# [DEVDOCS-4528]

1st commit: add "download consignment" support in PUT
2nd commit: correct "download consignment" structure in POST

## What changed?
1st commit: add "download consignment" support in PUT
2nd commit: correct "download consignment" structure in POST

## Anything else?
- Engineer ticket: ORDERS-4836
- This branch is based on `DEVDOCS-4416` branch: https://github.com/bigcommerce/api-specs/tree/DEVDOCS-4416

ping @bigcommerce/orders 

[ORDERS-4836]: https://bigcommercecloud.atlassian.net/browse/ORDERS-4836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEVDOCS-4528]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ