### PR TITLE
ORDERS-4923 Gift certificate consignment POST

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -485,6 +485,25 @@ paths:
                     country: United States
                     country_iso2: US
                     email: janedoe@example.com
+              Gift Certificate Consignment:
+                value:
+                  customer_id: 11
+                  consignments:
+                    email:
+                      gift_certificates:
+                        - recipient_email: jane@example.com
+                          line_items:
+                            gift_certificate_id: 184
+                  billing_address:
+                    first_name: Jane
+                    last_name: Doe
+                    street_1: 123 Main Street
+                    city: Austin
+                    state: Texas
+                    zip: '78751'
+                    country: United States
+                    country_iso2: US
+                    email: janedoe@example.com
         required: true
       responses:
         '200':
@@ -5058,6 +5077,31 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/giftCertificateConsignment_Get'
+    giftCertificateConsignment_Post:
+      x-examples:
+        example-1:
+          recipient_email: janedoe@example.com
+          line_items:
+            - gift_certificate_id: 11
+      type: object
+      properties:
+        recipient_email:
+          description: ''
+          example: 'janedoe@example.com'
+          type: string
+        line_items:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            properties:
+              gift_certificate_id:
+                description: ''
+                example: 2
+                type: integer
+      required:
+        - recipient_email
+        - line_items
     digitalConsignment_Post:
       x-examples:
         example-1:
@@ -5206,6 +5250,15 @@ components:
           maxItems: 1
           items:
             $ref: '#/components/schemas/digitalConsignment_Post'
+        email:
+          type: object
+          minItems: 1
+          maxItems: 1
+          properties:
+            gift_certificates:
+              type: array
+              items:
+                $ref: '#/components/schemas/giftCertificateConsignment_Post'
     orderConsignment_Put:
       title: ''
       type: object


### PR DESCRIPTION
# [DEVDOCS-4552](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4552)

## What changed?
Support Gift Certificate consignments in POST /v2/orders

## Anything else?
Engineering ticket: [ORDERS-4914](https://bigcommercecloud.atlassian.net/browse/ORDERS-4914)

@bigcommerce/dev-docs @bigcommerce/orders 