### PR TITLE
DEVDOCS-4449 Add Date Fields to Customs Information API - FIX

### DIFF
--- a/reference/shipping.v3.yml
+++ b/reference/shipping.v3.yml
@@ -382,8 +382,8 @@ components:
       title: customsInformation
       description: Data about the customs information object.
       type: object
-      minProperties: 5
-      maxProperties: 5
+      minProperties: 7
+      maxProperties: 7
       x-internal: false
       properties:
         product_id:
@@ -410,6 +410,16 @@ components:
           example: true
         hs_codes:
           $ref: '#/components/schemas/harmonizedSystemCodes'
+        createdAt:
+          type: string
+          description: Date and time of the customs information's creation. Read-Only.
+          format: date-time
+          example: 2022-09-21T14:15:00Z
+        updatedAt:
+          type: string
+          description: Date and time when the customs information was last updated. Read-Only.
+          format: date-time
+          example: 2022-09-21T14:15:00Z
     harmonizedSystemCodes:
       title: harmonizedSystemCodes
       description: |-


### PR DESCRIPTION
# [DEVDOCS-4449]

## What changed?

- changed `createdAt` & `updatedAt` to `created_at` & `updated_at`




[DEVDOCS-4449]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ