### PR TITLE
SHIPPING-1607 altering the documentation after adding in the channel id

### DIFF
--- a/reference/shipping_provider.yml
+++ b/reference/shipping_provider.yml
@@ -1984,14 +1984,12 @@ components:
                     type: string
             customer_id:
               type: integer
-        cart_id:
-          type: string
         store_id:
           type: string
         request_context:
           type: object
           title: Request Context
-          description: A collection of Reference Value objects.
+          description: A collection of Reference Value objects. Two examples of this are the cart_id and the channel_id.
           properties:
             reference_values:
               type: array

--- a/reference/shipping_provider.yml
+++ b/reference/shipping_provider.yml
@@ -1989,7 +1989,7 @@ components:
         request_context:
           type: object
           title: Request Context
-          description: A collection of Reference Value objects. Two examples of this are the cart_id and the channel_id.
+          description: A collection of Reference Value objects.
           properties:
             reference_values:
               type: array
@@ -2000,6 +2000,12 @@ components:
                 properties:
                   name:
                     type: string
+                    examples: 
+                      - channel_id
+                      - cart_id
                   value:
                     type: string
+                    examples:
+                      - 1
+                      - 770ded29-da45-4ee0-abc6-883e83c0e5ed   
       x-internal: false

--- a/reference/shipping_provider.yml
+++ b/reference/shipping_provider.yml
@@ -705,8 +705,6 @@ components:
                         type: string
                 customer_id:
                   type: integer
-            cart_id:
-              type: string
             store_id:
               type: string
             request_context:


### PR DESCRIPTION
# DEVDOCS-4570

## What changed?
- Removes cart_id as a field as it is no longer there
- Adds some description to the request_context field to describe that uses the request context

## Anything else?
Related branch
https://bigcommercecloud.atlassian.net/browse/SHIPPING-2535

@bigcommerce/shipping 