### PR TITLE
fixed wrong field names in v3/catalog/product

### DIFF
--- a/reference/catalog.v3.yml
+++ b/reference/catalog.v3.yml
@@ -947,7 +947,7 @@ paths:
                   meta:
                     type: object
                     properties: {}
-                  product_Full:
+                  data:
                     $ref: '#/components/schemas/product_Full'
             example-1:
               example:
@@ -1605,7 +1605,7 @@ paths:
                   meta:
                     type: object
                     properties: {}
-                  product_Full:
+                  data:
                     $ref: '#/components/schemas/product_Full'
             example-1:
               example:
@@ -28843,7 +28843,7 @@ components:
               meta:
                 type: object
                 properties: {}
-              product_Full:
+              data:
                 $ref: '#/components/schemas/product_Full'
         example-1:
           example:


### PR DESCRIPTION
PUT, POST to `v3/catalog/products` actually return `{"data": {}, "meta": {}}` and not `{"product_Full":{}, "meta":{}}` as stated in the specification.

## What changed?
Adjust field name in endpoint specification and example to match the actual behavior of the production API.
