### PR TITLE
Adding Rate limit - "Get All Records" DEVOCS-4669

### DIFF
--- a/reference/price_lists.v3.yml
+++ b/reference/price_lists.v3.yml
@@ -850,7 +850,11 @@ paths:
       tags:
         - Price Lists Records
       summary: Get All Price List Records
-      description: Returns a list of *Price List Records* associated with a *Price List*.
+      description: |-
+        Returns a list of *Price List Records* associated with a *Price List*.
+        **Notes**
+        * Up to 10 simultaneous GET requests are supported with this API. Running more than the allowed concurrent requests in parallel on the same store will result in a 429 status error and your additional requests will fail.
+        * In order to maximize performance, it is recommended to store Pricelist Records data to reduce number of calls.
       operationId: getPriceListRecordCollection
       parameters:
         - name: price_list_id


### PR DESCRIPTION
Get All Price List Records

Updating:
L.853 description: Returns a list of *Price List Records* associated with a *Price List*.

New value:
      description: |-
        Returns a list of *Price List Records* associated with a *Price List*.
        **Notes**
        * Up to 10 simultaneous GET requests are supported with this API. Running more than the allowed concurrent requests in parallel on the same store will result in a 429 status error and your additional requests will fail.
        * In order to maximize performance, it is recommended to store Pricelist Records data to reduce number of calls.

# [DEVDOCS-]

## What changed?
* thing_that_changed

## Anything else?
Related PRs, salient notes, etc
