### PR TITLE
Adding Rate limits - DEVDOCS-4669

### DIFF
--- a/reference/price_lists.v3.yml
+++ b/reference/price_lists.v3.yml
@@ -1761,7 +1761,12 @@ paths:
       tags:
         - Price Lists Records
       summary: Get Price Records by Variant
-      description: Returns *Price List Records* using the variant ID. Will also contain currency records.
+        description: |-
+        Returns *Price List Records* using the variant ID. Will also contain currency records.
+        
+        **Notes**
+        * Up to 50 simultaneous GET requests are supported with this API. Running more than the allowed concurrent requests in parallel on the same store will result in a `429` status error and your additional requests will fail.
+        * In order to maximize performance, it's recommended to store Pricelist Records data to reduce the number of calls.
       operationId: getPriceListRecordsByVariantId
       parameters:
         - name: price_list_id


### PR DESCRIPTION
# [DEVDOCS-4669]

## What changed?
* Adding ParRateLimiting for getRecordsWithVariantId endpoint for documentation - https://developer.bigcommerce.com/api-reference/9eb908ec0a0fc-get-price-records-by-variant

## Anything else?
Related to [1089](https://github.com/bigcommerce/api-specs/pull/1089/files)

Resource api-proxy: 
https://github.com/bigcommerce/api-proxy-java/blob/b1a8d820ffbfb17f45473f1b29760f38be3771d1/app/controllers/pricelists/PriceListRecordsController.scala#L98


[DEVDOCS-4669]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ