### PR TITLE
DEVDOCS-4634: [new] Orders V2, Update an order; gift cert consignment

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -182,7 +182,7 @@ paths:
                         value: 12
                       price_inc_tax: 12.45
                       price_ex_tax: 10.12
-              Updating a Order's Gift Certificate Consignment:
+              Updating an Order's Gift Certificate Consignment:
                 value:
                   consignments:
                     email:

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -182,6 +182,15 @@ paths:
                         value: 12
                       price_inc_tax: 12.45
                       price_ex_tax: 10.12
+              Updating a Order's Gift Certificate Consignment:
+                value:
+                  consignments:
+                    email:
+                      gift_certificates:
+                          - recipient_email: "jane.doe@bigcommerce.com"
+                            line_items:
+                              - gift_certificate_id: 123
+                              - quantity: 0
         required: true
       responses:
         '200':


### PR DESCRIPTION
# [DEVDOCS-4634]

## What changed?
* Add GC consignment support for Update an Order.

## Anything else?
Related PRs: https://github.com/BC-SEven/api-specs/tree/ORDERS-4981


[DEVDOCS-4634]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ