### PR TITLE
Update Orders - DEVDOCS-4700 order_source

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -3042,8 +3042,8 @@ components:
                           readOnly: true
                       readOnly: true
               order_source:
-                description: Orders submitted from the store’s website will include a `www` value. Orders submitted with the API will be set to `external`. A read-only value. Do not pass in a POST or PUT request.
-                example: www
+                description: Orders submitted from the store’s website will include a `www` value. Orders submitted with the Checkout API will be set to `checkout_api`.
+                example: www, iphone, android, mobile, manual
                 type: string
               external_source:
                 description: |-
@@ -4449,8 +4449,8 @@ components:
           example: false
           type: boolean
         order_source:
-          description: Orders submitted from the store’s website will include a `www` value. Orders submitted with the API will be set to `external`. This value is read-only. Do not pass in a POST or PUT.
-          example: www
+          description: Orders submitted from the store’s website will include a `www` value. Orders submitted with the Checkout API will be set to `checkout_api`.
+          example: www, iphone, android, mobile, manual
           type: string
         products:
           $ref: '#/components/schemas/products_Resource'


### PR DESCRIPTION


# [DEVDOCS-4700]

## What changed?
"order_source" can be updated via PUT request or passed with POST request during v2 Orders creation L3045 - remove "A read-only value. Do not pass in a POST or PUT request." L4452 - "This value is read-only. Do not pass in a POST or PUT."

## Anything else?
https://bigcommercecloud.atlassian.net/browse/CDEX-1687
