### PR TITLE
feat(tax): DEVDOCS-4783 Introduce should subtract store tax

### DIFF
--- a/reference/tax_settings.v3.yml
+++ b/reference/tax_settings.v3.yml
@@ -143,6 +143,10 @@ components:
             - FIXED
             - BASIC
             - DISABLE
+        should_subtract_store_tax:
+          default: true
+          type: boolean
+          description: This setting applies only if a merchant enters tax-inclusive prices. When enabled, the store subtracts the item's store tax rate before calculating tax using the shopper's tax zone. The tax-exclusive amount will be the same across all tax zones. When disabled, the tax-inclusive price remains the same across all tax zones; only the tax amount will vary based on the shopper's location. The tax-exclusive amount may vary among tax zones.    
     Tax_Settings_Req:
       type: object
       properties:

--- a/reference/tax_settings.v3.yml
+++ b/reference/tax_settings.v3.yml
@@ -146,7 +146,7 @@ components:
         should_subtract_store_tax:
           default: true
           type: boolean
-          description: This setting applies only if a merchant enters tax-inclusive prices. When enabled, the store subtracts the item's store tax rate before calculating tax using the shopper's tax zone. The tax-exclusive amount will be the same across all tax zones. When disabled, the tax-inclusive price remains the same across all tax zones; only the tax amount will vary based on the shopper's location. The tax-exclusive amount may vary among tax zones.    
+          description: This setting applies only if a merchant enters tax-inclusive prices. When enabled, the store subtracts the item's store tax rate before calculating tax using the shopper's tax zone. The tax-exclusive amount will be the same across all tax zones. When disabled, the tax-inclusive price remains the same across all tax zones; only the tax amount will vary based on the shopper's location. The tax-exclusive amount may vary among tax zones. These calculations are relevant for tax pricing and tax quotations that use basic tax.    
     Tax_Settings_Req:
       type: object
       properties:
@@ -177,7 +177,7 @@ components:
         should_subtract_store_tax:
           default: true
           type: boolean
-          description: This setting applies only if a merchant enters tax-inclusive prices. When enabled, the store subtracts the item's store tax rate before calculating tax using the shopper's tax zone. The tax-exclusive amount will be the same across all tax zones. When disabled, the tax-inclusive price remains the same across all tax zones; only the tax amount will vary based on the shopper's location. The tax-exclusive amount may vary among tax zones.
+          description: This setting applies only if a merchant enters tax-inclusive prices. When enabled, the store subtracts the item's store tax rate before calculating tax using the shopper's tax zone. The tax-exclusive amount will be the same across all tax zones. When disabled, the tax-inclusive price remains the same across all tax zones; only the tax amount will vary based on the shopper's location. The tax-exclusive amount may vary among tax zones. These calculations are relevant for tax pricing and tax quotations that use basic tax.
     MetaOpen:
       title: Response meta
       type: object

--- a/reference/tax_settings.v3.yml
+++ b/reference/tax_settings.v3.yml
@@ -31,7 +31,7 @@ paths:
         '200':
           description: OK
           content:
-            application/json: 
+            application/json:
               schema:
                 type: object
                 properties:
@@ -170,6 +170,10 @@ components:
             - FIXED
             - BASIC
             - DISABLE
+        should_subtract_store_tax:
+          default: true
+          type: boolean
+          description: This setting applies only if a merchant enters tax-inclusive prices. When enabled, the store subtracts the item's store tax rate before calculating tax using the shopper's tax zone. The tax-exclusive amount will be the same across all tax zones. When disabled, the tax-inclusive price remains the same across all tax zones, only the tax amount will vary based on the shopper's location. The tax-exclusive amount may vary between tax zones.
     MetaOpen:
       title: Response meta
       type: object

--- a/reference/tax_settings.v3.yml
+++ b/reference/tax_settings.v3.yml
@@ -173,7 +173,7 @@ components:
         should_subtract_store_tax:
           default: true
           type: boolean
-          description: This setting applies only if a merchant enters tax-inclusive prices. When enabled, the store subtracts the item's store tax rate before calculating tax using the shopper's tax zone. The tax-exclusive amount will be the same across all tax zones. When disabled, the tax-inclusive price remains the same across all tax zones, only the tax amount will vary based on the shopper's location. The tax-exclusive amount may vary between tax zones.
+          description: This setting applies only if a merchant enters tax-inclusive prices. When enabled, the store subtracts the item's store tax rate before calculating tax using the shopper's tax zone. The tax-exclusive amount will be the same across all tax zones. When disabled, the tax-inclusive price remains the same across all tax zones; only the tax amount will vary based on the shopper's location. The tax-exclusive amount may vary among tax zones.
     MetaOpen:
       title: Response meta
       type: object


### PR DESCRIPTION
# [DEVDOCS-4783](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4783)

## What changed?
Update the `tax_settings` documentation  with a new field `should_subtract_store_tax`
This will allow the merchants to both read and set the new `should_subtract_store_tax` via the bigcommerce public API

## Anything else?
PR: https://github.com/bigcommerce/bigcommerce/pull/52265
JIRA Ticket: https://bigcommercecloud.atlassian.net/browse/TAX-1421
JIRA Ticket: https://github.com/bigcommerce/bigcommerce/pull/52265
(naming change from `tax_should_unwind_store_tax` -> `should_subtract_store_tax`)

ping @bigcommerce/shipping @bc-andreadao @bigcommerce/devdocs-codeowners 


[DEVDOCS-4783]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-4783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ