### PR TITLE
DEVDOCS-4893: [update] Update Orders v2 API doc for DELETE all reques…

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -406,6 +406,8 @@ paths:
       summary: Delete All Orders
       tags:
         - Orders
+      parameters:
+        - $ref: '#/components/parameters/limit'
       responses:
         '204':
           description: ''


### PR DESCRIPTION
…t to support limit param

**What changed?**
We have fixed an issue for [ORDERS-5448](https://bigcommercecloud.atlassian.net/browse/ORDERS-5448). The delete all orders API is supporting limit param now.

**Anything else?**
We can release DEVDOCS-4893 after confirming ORDERS-5448 is working as expected on production environment.

[ORDERS-5448]: https://bigcommercecloud.atlassian.net/browse/ORDERS-5448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ping @bigcommerce/dev-docs  @bigcommerce/orders 