### PR TITLE
DEVDOCS-4931: [update] Tax Connection API, edit 404 error message

### DIFF
--- a/reference/tax.v3.yml
+++ b/reference/tax.v3.yml
@@ -69,7 +69,7 @@ paths:
                       username: MyDisconnectedTaxProviderAccount
                       configured: false
         '404':
-          description: Provider or provider connection does not exist.
+          description: Provider or provider connection does not exist
       tags:
         - Tax Provider Connection
     put:

--- a/reference/tax.v3.yml
+++ b/reference/tax.v3.yml
@@ -69,7 +69,7 @@ paths:
                       username: MyDisconnectedTaxProviderAccount
                       configured: false
         '404':
-          description: Provider does not exist
+          description: Provider or provider connection does not exist
       tags:
         - Tax Provider Connection
     put:

--- a/reference/tax.v3.yml
+++ b/reference/tax.v3.yml
@@ -69,7 +69,7 @@ paths:
                       username: MyDisconnectedTaxProviderAccount
                       configured: false
         '404':
-          description: Provider or provider connection does not exist
+          description: Provider or provider connection does not exist.
       tags:
         - Tax Provider Connection
     put:


### PR DESCRIPTION
## What changed?
When a client attempts to disconnect a tax provider that is not connected to the store, it now throws a 404 error and notifies the client that they are trying to disconnect a tax provider that does not exist.

## Anything else?
Code change: https://github.com/bigcommerce/bigcommerce/pull/52321

ping @bigcommerce/shipping  @bc-andreadao @bigcommerce/devdocs-codeowners 