### PR TITLE
DEVDOCS-5230 /v2/orders support include of consignments and consignments.line_items

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -76,6 +76,17 @@ paths:
       summary: Get an Order
       tags:
         - Orders
+      parameters: 
+        - name: include
+          in: query
+          description: |-
+            * `consignments` - include the response of `/orders/{order_id}/consignments`
+            * `consignments.line_items` - include the response of `/orders/{order_id}/products` in consignments. This implies `include=consignments`. 
+          schema:
+            type: string  
+            enum:
+              - consignments
+              - consignments.line_items
       responses:
         '200':
           $ref: '#/components/responses/order_Resp'
@@ -899,6 +910,14 @@ paths:
         name: order_id
         in: path
         required: true
+      - name: include
+        in: query
+        description: |-
+          * `consignments.line_items` - include the response of `/orders/{order_id}/products` in consignments.
+        schema:
+          type: string  
+          enum:
+            - consignments.line_items
     get:
       summary: Get Consignments
       tags:


### PR DESCRIPTION
# [DEVDOCS-5230](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5230)


## What changed?
Add support for the following query parameters
* `include=consignment` in  `GET /v2/orders/{{order_id}}`
* `include=consignment.line_items` in `GET /v2/orders/{{order_id}}/consignments`

## Anything else?

```
> spectral lint  reference/orders.v2.oas2.yml
No results with a severity of 'error' found!
```

* https://github.com/bigcommerce/bigcommerce/pull/53387

<img width="933" alt="Screenshot 2023-07-14 at 8 07 45 am" src="https://github.com/bigcommerce/api-specs/assets/2238749/06260692-7efb-4aa7-bc2b-967d459df5ba">

<img width="959" alt="Screenshot 2023-07-14 at 8 08 04 am" src="https://github.com/bigcommerce/api-specs/assets/2238749/46fce66e-27fb-41fb-9bae-aea7f8aad49f">



ping @bc-tgomez  @bigcommerce/team-orders 

[DEVDOCS-5230]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ