### PR TITLE
DEVDOCS-5230 Add includes for GET all Orders and Create Order

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -77,16 +77,7 @@ paths:
       tags:
         - Orders
       parameters: 
-        - name: include
-          in: query
-          description: |-
-            * `consignments` - include the response returned from the request to the `/orders/{order_id}/consignments` endpoint.
-            * `consignments.line_items` - include the response returned from the request to the `/orders/{order_id}/products` endpoint in consignments. This implies `include=consignments`. 
-          schema:
-            type: string  
-            enum:
-              - consignments
-              - consignments.line_items
+        - $ref: '#/components/parameters/order_includes'
       responses:
         '200':
           $ref: '#/components/responses/order_Resp'
@@ -245,6 +236,7 @@ paths:
         - $ref: '#/components/parameters/sort'
         - $ref: '#/components/parameters/is_deleted'
         - $ref: '#/components/parameters/channel_id'
+        - $ref: '#/components/parameters/order_includes'
       responses:
         '200':
           $ref: '#/components/responses/orderCollection_Resp'
@@ -279,6 +271,7 @@ paths:
         - Orders
       parameters:
         - $ref: '#/components/parameters/ContentType'
+        - $ref: '#/components/parameters/order_includes'
       requestBody:
         content:
           application/json:
@@ -1240,6 +1233,17 @@ components:
       description: Shipping consignment ID.
       schema:
         type: integer
+    order_includes:
+      name: include
+      in: query
+      description: |-
+        * `consignments` - include the response returned from the request to the `/orders/{order_id}/consignments` endpoint.
+        * `consignments.line_items` - include the response returned from the request to the `/orders/{order_id}/products` endpoint in consignments. This implies `include=consignments`. 
+      schema:
+        type: string  
+        enum:
+          - consignments
+          - consignments.line_items 
   responses:
     orderStatusCollection_Resp:
       description: Get All Order Status Collection Response.


### PR DESCRIPTION

# [DEVDOCS-5230](https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5230)


## What changed?
* Follow on from https://github.com/bigcommerce/api-specs/pull/1380#issue-1808646440 to also add the relevant `include` to `GET /v2/orders` and `POST`

## Anything else?


ping @bc-tgomez 


[DEVDOCS-5230]: https://bigcommercecloud.atlassian.net/browse/DEVDOCS-5230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ