### PR TITLE
[SHIPPING-2792]: [revise] Ordersv2, Update tracking_link details

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -622,11 +622,11 @@ paths:
 
         There are three methods for generating a tracking link for a shipment:
 
-        1. Use `shipping_provider` and `tracking_number`: This generates an automatic tracking link that you can click from the BigCommerce control panel and customer-facing emails. However, the `tracking_link` property in the API response will remain empty.
+        1. Use `shipping_provider` and `tracking_number`: This generates an automatic tracking link that you can click from the BigCommerce control panel and customer-facing emails. The `generated_tracking_link` property in the API response represents this tracking link. The `tracking_link` property in the API response will remain empty.
 
-        2. Use `tracking_carrier` and `tracking_number`: This also creates an automatic tracking link that you can click in both the BigCommerce control panel and customer-facing emails. Like the previous method, the `tracking_link` property in the API response will be empty.
+        2. Use `tracking_carrier` and `tracking_number`: This also creates an automatic tracking link that you can click in both the BigCommerce control panel and customer-facing emails. Like the previous method, the `generated_tracking_link` property in the API response represents this tracking link. The `tracking_link` property in the API respose will remain empty.
 
-        3. Supply a custom `tracking_link`: By providing a value for the `tracking_link` property, you can use your own tracking link within the BigCommerce control panel and in customer-facing emails. The API response will return your supplied `tracking_link` as part of the response. 
+        3. Supply a custom `tracking_link`: By providing a value for the `tracking_link` property, you can use your own tracking link within the BigCommerce control panel and in customer-facing emails. The API response will return your supplied tracking link as part of the `tracking_link` property in the response. In this situation there is no `generated_tracking_link` and thus will be empty. 
         
         Acceptable values for `shipping_provider` include an empty string (`""`), `auspost`, `carrier_{your_carrier_id}` (only used if the carrier is a [third-party Shipping Provider](/api-docs/providers/shipping)), `canadapost`, `endicia`, `usps`, `fedex`, `royalmail`, `ups`, `upsready`, `upsonline`, or `shipperhq`.
         
@@ -2399,6 +2399,7 @@ components:
                     - order_product_id: 188
                       product_id: 0
                       quantity: 1
+                  generated_tracking_link: http://trkcnfrm1.smi.usps.com/PTSInternetWeb/InterLabelInquiry.do?strOrigTrackNum=EJ958083578US
                 - id: 7
                   order_id: 225
                   customer_id: 11
@@ -2441,6 +2442,7 @@ components:
                     - order_product_id: 189
                       product_id: 0
                       quantity: 1
+                  generated_tracking_link: http://trkcnfrm1.smi.usps.com/PTSInternetWeb/InterLabelInquiry.do?strOrigTrackNum=EJ958083578US
     orderShipment_Resp:
       description: ''
       content:
@@ -2461,6 +2463,7 @@ components:
                 comments: Ready to go...
                 shipping_provider: usps
                 tracking_carrier: ''
+                tracking_link: ''
                 billing_address:
                   first_name: Jane
                   last_name: Doe
@@ -2494,6 +2497,7 @@ components:
                   - order_product_id: 195
                     product_id: 0
                     quantity: 1
+                generated_tracking_link: http://trkcnfrm1.smi.usps.com/PTSInternetWeb/InterLabelInquiry.do?strOrigTrackNum=EJ958083578US
     orderCount_Resp:
       description: ''
       content:
@@ -3702,7 +3706,7 @@ components:
             Acceptable values for `tracking_carrier` include an empty string (`""`) or one of the valid [tracking-carrier values](https://github.com/bigcommerce/dev-docs/blob/master/assets/csv/tracking_carrier_values.csv).
         tracking_link:
           type: string
-          description: Returns a tracking link from the shipping service.
+          description: The custom tracking link supplied on POST or PUT shipments. For the auto generated tracking link see generated_tracking_link property.
         comments:
           type: string
           description: Comments the shipper wishes to add.
@@ -3727,6 +3731,9 @@ components:
               quantity:
                 type: integer
                 example: 2
+        generated_tracking_link:
+          type: string
+          description: The tracking link that is generated using the combination of either the tracking_number and shipping_provider or tracking_number and tracking_carrier. Will be empty if the custom tracking_link value is provided.
       x-internal: false
     orderConsignments_Resource:
       title: orderConsignments_Resource
@@ -4064,7 +4071,7 @@ components:
           maxLength: 50
         tracking_link:
           type: string
-          description: Tracking link that is associated with your shipment.
+          description: The custom tracking link supplied on POST or PUT shipments. For the auto generated tracking link see generated_tracking_link property.
           example: https://www.mycustomtrackinglink.com/tracking
           maxLength: 500
         shipping_method:
@@ -4150,7 +4157,7 @@ components:
             Acceptable values for `tracking_carrier` include an empty string (`""`) or one of the valid [tracking-carrier values](https://github.com/bigcommerce/dev-docs/blob/master/assets/csv/tracking_carrier_values.csv).
         tracking_link:
           type: string
-          description: Tracking link that is associated with your shipment.
+          description: The custom tracking link supplied on POST or PUT shipments. For the auto generated tracking link see generated_tracking_link property.
           example: https://www.mycustomtrackinglink.com/tracking
           maxLength: 500
         comments:


### PR DESCRIPTION
No Dev Docs ticket.

This doc task acts as a follow on from the work done in [SHIPPING-2792](https://bigcommercecloud.atlassian.net/browse/SHIPPING-2792) (which adds the new API property of  `generated_tracking_link` to the shipments API).

## What changed?
* Include `generated_tracking_link` property as part of our API responses to the order/shipments API
* Update examples to show how the `generated_tracking_link` is presented to the API client.
* Update usage description on how to use this 

## Anything else?
If interested, here is the [PR](https://github.com/bigcommerce/bigcommerce/pull/54299) that adds this feature

ping @bigcommerce/team-orders @bigcommerce/team-shipping @bc-tgomez @donald-nguyen-bc 


[SHIPPING-2792]: https://bigcommercecloud.atlassian.net/browse/SHIPPING-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ