### PR TITLE
docs(orders): ORDERS-5912 Expose discounted_total_inc_tax on the orde…

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -2048,7 +2048,7 @@ components:
                 brand: BigCommerce
                 applied_discounts: []
                 product_options: []
-                discounted_total_inc_tax: "0.0000"
+                discounted_total_inc_tax: '37.2300'
             Product with file upload:
               value:
                 - id: 35

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -1940,7 +1940,7 @@ components:
                       display_style: Pick list
                   configurable_fields: []
                   gift_certificate_id: null
-                  discounted_total_inc_tax: '0.0000'
+                  discounted_total_inc_tax: '63.6400'
                 - id: 66
                   order_id: 149
                   product_id: 86
@@ -3496,7 +3496,10 @@ components:
         discounted_total_inc_tax:
           type: string
           example: '0.0000'
-          description: The discounted line item total.
+          description: |-
+            Represent the correct total amount of the line item after deducting all the discounts and including the tax. This number can be used for accounting purpose.
+            
+            Why we cannot use the `total_inc_tax` amount? It's because `total_ex_tax + total_tax != total_inc_tax` in multiple scenarios, especially when we have a mix-match of entered price exclusive of tax, and display price inclusive of tax, and vice versa. So that field `total_inc_tax` is not reliable for accounting purpose and the value may be wrong.
     orderCount:
       title: orderCount
       example:

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -1940,6 +1940,7 @@ components:
                       display_style: Pick list
                   configurable_fields: []
                   gift_certificate_id: null
+                  discounted_total_inc_tax: '0.0000'
                 - id: 66
                   order_id: 149
                   product_id: 86
@@ -1988,6 +1989,7 @@ components:
                   product_options: []
                   configurable_fields: []
                   gift_certificate_id: null
+                  discounted_total_inc_tax: '0.0000'
     orderProductLineItem_Resp:
       description: ''
       content:
@@ -2046,6 +2048,7 @@ components:
                 brand: BigCommerce
                 applied_discounts: []
                 product_options: []
+                discounted_total_inc_tax: "0.0000"
             Product with file upload:
               value:
                 - id: 35
@@ -3490,6 +3493,10 @@ components:
           example: 52
           description: ID of the associated gift certificate.
           nullable: true
+        discounted_total_inc_tax:
+          type: string
+          example: '0.0000'
+          description: The discounted line item total.
     orderCount:
       title: orderCount
       example:


### PR DESCRIPTION
…rs v2 api

# [DEVDOCS-]
ORDERS-5912

## What changed?
Add new discounted_total_inc_tax for the API response with `List Order Products` and `Get an Order Product'
update example for the API response with `List Order Products` and `Get an Order Product'

## Anything else?
This functionality was provided through https://bigcommercecloud.atlassian.net/browse/ORDERS-5592 and https://bigcommercecloud.atlassian.net/browse/ORDERS-5911.

ping @bigcommerce/team-orders @bigcommerce/dev-docs-team 
