### PR TITLE
[external] bugfix: fix escaping in orders

### DIFF
--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -2114,7 +2114,7 @@ components:
                     display_value: BigCommerceLogo.jpeg
                     display_value_customer: BigCommerceLogo.jpeg
                     display_value_merchant: BigCommerceLogo.jpeg
-                    value: {\"originalName\":\"BigCommerceLogo.jpeg\",\"temporaryPath\":\"121_fbfb71dfc5a5d911f62d8e35dedd6e45.jpeg\",\"path\":\"f606efcae7e179970b19c3658142c5d0.jpeg\"}
+                    value: "{\"originalName\":\"BigCommerceLogo.jpeg\",\"temporaryPath\":\"121_fbfb71dfc5a5d911f62d8e35dedd6e45.jpeg\",\"path\":\"f606efcae7e179970b19c3658142c5d0.jpeg\"}"
                     type: File upload field
                     name: Custom Logo Engraving
                     display_style: ""


### PR DESCRIPTION
# [DEVDOCS-]
The OpenAPI parser was unable to comprehend the escaping approach of this example on an orders endpoint. I've modified it to use single quotes so that the double quotes don't need to be escaped. 

## What changed?
Provide a bulleted list in the present tense
* change escaping of orders example for improved ability to parse.

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
