### PR TITLE
bugfix: remove duplicate image id path parameters

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -2334,14 +2334,6 @@ paths:
       description: Returns a single *Product Image*. Optional parameters can be passed in.
       operationId: getProductImageById
       parameters:
-        - name: image_id
-          in: path
-          description: |
-            The ID of the `Image` that is being operated on.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -2415,13 +2407,6 @@ paths:
       operationId: updateProductImage
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: image_id
-          in: path
-          description: |
-            The ID of the `Image` that is being operated on.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -2601,14 +2586,6 @@ paths:
       summary: Delete a Product Image
       description: Deletes a *Product Image*.
       operationId: deleteProductImage
-      parameters:
-        - name: image_id
-          in: path
-          description: |
-            The ID of the `Image` that is being operated on.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
# [DEVDOCS-]
The image ID path parameter on the product image endpoint is defined at the endpoint level and on the method level in multiple places. 

This leads to duplicate params in the doc output. Remove duplicates.

<img width="1532" alt="Screenshot 2023-09-03 at 07 57 25" src="https://github.com/bigcommerce/api-specs/assets/553566/027fca05-6630-49cc-8950-d1b586061c67">


## What changed?
Provide a bulleted list in the present tense
* remove duplicate image id path parameters on product image endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
