### PR TITLE
bugfix: remove duplicate brand id params

### DIFF
--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -620,14 +620,6 @@ paths:
       description: Returns a single *Brand*. Optional filter parameters can be passed in.
       operationId: getBrandById
       parameters:
-        - name: brand_id
-          in: path
-          description: |
-            The ID of the `Brand` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -707,13 +699,6 @@ paths:
       operationId: updateBrand
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: brand_id
-          in: path
-          description: |
-            The ID of the `Brand` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -975,14 +960,6 @@ paths:
       summary: Delete a Brand
       description: Deletes a *Brand*.
       operationId: deleteBrandById
-      parameters:
-        - name: brand_id
-          in: path
-          description: |
-            The ID of the `Brand` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION

# [DEVDOCS-]
brand id param is defined on the endpoint but duplicate definitions are also on the method level definitions.

<img width="868" alt="Screenshot 2023-09-03 at 20 22 31" src="https://github.com/bigcommerce/api-specs/assets/553566/cc2d97a0-9e22-4960-ba82-fb066a2f9f8a">
## What changed?
Provide a bulleted list in the present tense
* removed duplicate brand id param definitions

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
