### PR TITLE
bugfix: remove duplicate bulk pricing rule id param definition

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -4860,14 +4860,6 @@ paths:
       description: Returns a single *Bulk Pricing Rule*. Optional parameters can be passed in.
       operationId: getBulkPricingRuleById
       parameters:
-        - name: bulk_pricing_rule_id
-          in: path
-          description: |
-            The ID of the `BulkPricingRule`.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -4943,13 +4935,6 @@ paths:
       operationId: updateBulkPricingRule
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: bulk_pricing_rule_id
-          in: path
-          description: |
-            The ID of the `BulkPricingRule`.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -5112,14 +5097,6 @@ paths:
       summary: Delete a Bulk Pricing Rule
       description: Deletes a *Bulk Pricing Rule*.
       operationId: deleteBulkPricingRuleById
-      parameters:
-        - name: bulk_pricing_rule_id
-          in: path
-          description: |
-            The ID of the `BulkPricingRule`.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
# [DEVDOCS-]
 remove duplicate bulk pricing rule id param definition.

Parameter is already defined on the endpoint and is being redefined on the method level

<img width="812" alt="Screenshot 2023-09-03 at 20 28 19" src="https://github.com/bigcommerce/api-specs/assets/553566/2b7e3c28-7c6e-4619-8647-36bc903a9105">


## What changed?
Provide a bulleted list in the present tense
*  remove duplicate bulk pricing rule id param definition

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
