### PR TITLE
bugfix: remove duplicate complex rule id path params

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -3563,14 +3563,6 @@ paths:
       description: Returns a single *Complex Rule*. Optional parameters can be passed in.
       operationId: getComplexRuleById
       parameters:
-        - name: complex_rule_id
-          in: path
-          description: |
-            The ID of the `ComplexRule`.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -3764,14 +3756,6 @@ paths:
       operationId: updateComplexRule
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: complex_rule_id
-          in: path
-          description: |
-            The ID of the `ComplexRule`.
-          required: true
-          schema:
-            type: integer
-
       requestBody:
         content:
           application/json:
@@ -4095,14 +4079,6 @@ paths:
       summary: Delete a Complex Rule
       description: Deletes a product *Complex Rule*.
       operationId: deleteComplexRuleById
-      parameters:
-        - name: complex_rule_id
-          in: path
-          description: |
-            The ID of the `ComplexRule`.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
# [DEVDOCS-]
Remove duplicate complex rule ID param on method level when already defined on endpoint level

<img width="1040" alt="Screenshot 2023-09-04 at 08 10 35" src="https://github.com/bigcommerce/api-specs/assets/553566/61be448f-df29-40b2-8cb0-48ac082ce1cc">


## What changed?
Provide a bulleted list in the present tense
* remove duplicate complex rule ID path param definition

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
