### PR TITLE
bugfix: remove duplicate customer id param on consent endpoint.

### DIFF
--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -1472,8 +1472,6 @@ paths:
         - Customer Consent
       operationId: CustomersConsentByCustomerId_GET
       deprecated: false
-      parameters:
-        - $ref: '#/components/parameters/customerId'
       responses:
         '200':
           $ref: '#/components/responses/consent_Resp'
@@ -1510,7 +1508,6 @@ paths:
           schema:
             type: string
             default: application/json
-        - $ref: '#/components/parameters/customerId'
       requestBody:
         content:
           application/json:
@@ -1543,11 +1540,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
     parameters:
-      - schema:
-          type: string
-        name: customerId
-        in: path
-        required: true
+      - $ref: '#/components/parameters/customerId'
   '/customers/{customerId}/stored-instruments':
     get:
       summary: Get Stored Instruments


### PR DESCRIPTION
It is already defined on the endpoint, it does not need to be defined on each method

![Screenshot 2023-09-04 at 09 16 26](https://github.com/bigcommerce/api-specs/assets/553566/1ec66c49-a95d-4413-add1-e798d67a781b)


# [DEVDOCS-]
{Ticket number or summary of work}

## What changed?
Provide a bulleted list in the present tense
* remove duplicate customer_id param definition on customer consent endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
