### PR TITLE
bugfix: remove duplicate custom field id param.

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -4358,14 +4358,6 @@ paths:
       description: Returns a single *Custom Field*. Optional parameters can be passed in.
       operationId: getCustomFieldById
       parameters:
-        - name: custom_field_id
-          in: path
-          description: |
-            The ID of the `CustomField`.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -4430,13 +4422,6 @@ paths:
       operationId: updateCustomField
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: custom_field_id
-          in: path
-          description: |
-            The ID of the `CustomField`.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -4577,14 +4562,6 @@ paths:
       summary: Delete a Custom Field
       description: Deletes a product *Custom Field*.
       operationId: deleteCustomFieldById
-      parameters:
-        - name: custom_field_id
-          in: path
-          description: |
-            The ID of the `CustomField`.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: '`204 No Content`. Action has been enacted and no further information is to be supplied. `null` is returned.'


### PR DESCRIPTION
It is already defined on an endpoint level and is not required on a method level.

![Screenshot 2023-09-04 at 11 29 35](https://github.com/bigcommerce/api-specs/assets/553566/a9f257d4-a2e4-4b5d-a7b4-a0d93fe698f3)


# [DEVDOCS-]

## What changed?
* remove duplicate custom field id param.

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
