### PR TITLE
bugfix: remove duplicate brand_id param on brand image endpoint

### DIFF
--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -1509,13 +1509,6 @@ paths:
       operationId: createBrandImage
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: brand_id
-          in: path
-          description: |
-            The ID of the `Brand` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           multipart/form-data:
@@ -1602,14 +1595,6 @@ paths:
       summary: Delete a Brand Image
       description: Deletes a *Brand Image*.
       operationId: deleteBrandImage
-      parameters:
-        - name: brand_id
-          in: path
-          description: |
-            The ID of the `Brand` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
brand_id param is already defined on an endpoint level and is not required on the method level.
![Screenshot 2023-09-04 at 12 02 47](https://github.com/bigcommerce/api-specs/assets/553566/c76277b9-318e-4b53-bfcc-1414e0d12812)

# [DEVDOCS-]

## What changed?
Provide a bulleted list in the present tense
* remove duplicate brand_id param on brand image endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
