### PR TITLE
bugfix: remove duplicate category_id on category image endpoint

### DIFF
--- a/reference/catalog/categories_catalog.v3.yml
+++ b/reference/catalog/categories_catalog.v3.yml
@@ -1643,13 +1643,6 @@ paths:
       operationId: createCategoryImage
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: category_id
-          in: path
-          description: |
-            The ID of the `Category` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           multipart/form-data:
@@ -1738,14 +1731,6 @@ paths:
       summary: Delete a Category Image
       description: Deletes a *Cateogory Image*.
       operationId: deleteCategoryImage
-      parameters:
-        - name: category_id
-          in: path
-          description: |
-            The ID of the `Category` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
category_id param is already defined as a parameter on an endpoint, it is not needed on the method level as well.
![Screenshot 2023-09-04 at 12 05 32](https://github.com/bigcommerce/api-specs/assets/553566/61110fa2-e871-4633-8ea3-d090e4d02f50)

# [DEVDOCS-]

## What changed?
Provide a bulleted list in the present tense
* remove duplicate `category_id` param definition on the category image endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
