### PR TITLE
bugfix: remove duplicate brand_id param on brand metafield endpoints.

### DIFF
--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -998,14 +998,6 @@ paths:
       description: 'Returns a list of *Brand Metafields*. Optional filter parameters can be passed in. '
       operationId: getBrandMetafieldsByBrandId
       parameters:
-        - name: brand_id
-          in: path
-          description: |
-            The ID of the `Brand` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
-
         - name: id
           in: query
           description: |
@@ -1178,13 +1170,6 @@ paths:
       operationId: createBrandMetafield
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: brand_id
-          in: path
-          description: |
-            The ID of the `Brand` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Already defined on the endpoint level. Not required on the method level as well

![Screenshot 2023-09-04 at 12 10 12](https://github.com/bigcommerce/api-specs/assets/553566/35af1f71-928f-4ad8-8c3e-b2dc8d2fba92)


# [DEVDOCS-]

## What changed?
Provide a bulleted list in the present tense
* remove duplicate `brand_id` param definition on brand metafield endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
