### PR TITLE
bugfix: remove duplicate metafield_id param definition on product metafield endpoint

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -5367,14 +5367,6 @@ paths:
       description: Returns a single *Product Metafield*. Optional parameters can be passed in.
       operationId: getProductMetafieldByProductId
       parameters:
-        - name: metafield_id
-          in: path
-          description: |
-            The ID of the `Metafield`.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -5440,13 +5432,6 @@ paths:
       operationId: updateProductMetafield
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: metafield_id
-          in: path
-          description: |
-            The ID of the `Metafield`.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -5507,14 +5492,6 @@ paths:
       summary: Delete a Product Metafield
       description: Deletes a *Product Metafield*.
       operationId: deleteProductMetafieldById
-      parameters:
-        - name: metafield_id
-          in: path
-          description: |
-            The ID of the `Metafield`.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
Parameter defined on both the endpoint and method level.
![Screenshot 2023-09-04 at 12 13 45](https://github.com/bigcommerce/api-specs/assets/553566/669788ed-fc9f-4f04-bae7-3d99bf5402e5)



# [DEVDOCS-]

## What changed?
Provide a bulleted list in the present tense
* remove duplicate metafield_id param on product metafield endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
