### PR TITLE
bugfix: remove duplicate variant metafield and variant id params.

### DIFF
--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -795,21 +795,6 @@ paths:
       description: Returns a single product variant *Metafield*. Optional parameters can be passed in.
       operationId: getVariantMetafieldByProductIdAndVariantId
       parameters:
-        - name: metafield_id
-          in: path
-          description: |
-            The ID of the `Metafield`.
-          required: true
-          schema:
-            type: integer
-        - name: variant_id
-          in: path
-          description: |
-            ID of the variant on a product, or on an associated Price List Record.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -875,20 +860,6 @@ paths:
       operationId: updateVariantMetafield
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: metafield_id
-          in: path
-          description: |
-            The ID of the `Metafield`.
-          required: true
-          schema:
-            type: integer
-        - name: variant_id
-          in: path
-          description: |
-            ID of the variant on a product, or on an associated Price List Record.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -949,21 +920,6 @@ paths:
       summary: Delete a Variant Metafield
       description: Deletes a product variant *Metafield*.
       operationId: deleteVariantMetafieldById
-      parameters:
-        - name: metafield_id
-          in: path
-          description: |
-            The ID of the `Metafield`.
-          required: true
-          schema:
-            type: integer
-        - name: variant_id
-          in: path
-          description: |
-            ID of the variant on a product, or on an associated Price List Record.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
metafield_id and variant_id params only need to be defined at endpoint level. Method level definitions are duplicates.

![Screenshot 2023-09-04 at 12 44 11](https://github.com/bigcommerce/api-specs/assets/553566/62ecabf4-6920-4e72-

9dc1-14ac0ee94847)

# [DEVDOCS-]

## What changed?
* remove duplicate metafield_id and variant_id param definitions on variant metafields endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
