### PR TITLE
bugfix: remove duplicate product modifier id param

### DIFF
--- a/reference/catalog/product-modifiers_catalog.v3.yml
+++ b/reference/catalog/product-modifiers_catalog.v3.yml
@@ -846,14 +846,6 @@ paths:
       description: Returns a single *Product Modifier*. Optional parameters can be passed in.
       operationId: getModifierById
       parameters:
-        - name: modifier_id
-          in: path
-          description: |
-            The ID of the `Modifier`.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -906,13 +898,6 @@ paths:
       operationId: updateModifier
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: modifier_id
-          in: path
-          description: |
-            The ID of the `Modifier`.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -1486,14 +1471,6 @@ paths:
       summary: Delete a Modifier
       description: Deletes a *Product Modifier*.
       operationId: deleteModifierById
-      parameters:
-        - name: modifier_id
-          in: path
-          description: |
-            The ID of the `Modifier`.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
Already defined on endpoint level, not required on the method level.

![Screenshot 2023-09-04 at 12 52 34](https://github.com/bigcommerce/api-specs/assets/553566/d4e426f1-59af-41fe-9c9c-54bf03b50f65)


# [DEVDOCS-]

## What changed?
Provide a bulleted list in the present tense
* remove duplicate modifier_id param from product modifier endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
