### PR TITLE
bugfix: remove product variant options option_id param

### DIFF
--- a/reference/catalog/product-variant-options_catalog.v3.yml
+++ b/reference/catalog/product-variant-options_catalog.v3.yml
@@ -796,14 +796,6 @@ paths:
       description: Returns a single *Variant Option*. Optional parameters can be passed in.
       operationId: getOptionById
       parameters:
-        - name: option_id
-          in: path
-          description: |
-            The ID of the `Option`.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -860,13 +852,6 @@ paths:
       operationId: updateOption
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: option_id
-          in: path
-          description: |
-            The ID of the `Option`.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -1475,14 +1460,6 @@ paths:
       summary: Delete a Product Variant Option
       description: Deletes a *Variant Option*.
       operationId: deleteOptionById
-      parameters:
-        - name: option_id
-          in: path
-          description: |
-            The ID of the `Option`.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
Use definition on endpoint level and remove those on a method level.

![Screenshot 2023-09-04 at 12 53 46](https://github.com/bigcommerce/api-specs/assets/553566/4852b2a4-affb-46f7-9456-9ff506423a2f)


# [DEVDOCS-]


## What changed?
Provide a bulleted list in the present tense
* remove duplicate option_id param from product variant options endpoint 

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
