### PR TITLE
bugfix: remove duplicate variant_id param from product variants endpoint

### DIFF
--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -379,14 +379,6 @@ paths:
       description: Returns a single product *Variant*. Optional parameters can be passed in.
       operationId: getVariantById
       parameters:
-        - name: variant_id
-          in: path
-          description: |
-            ID of the variant on a product, or on an associated Price List Record.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -473,13 +465,6 @@ paths:
       operationId: updateVariant
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: variant_id
-          in: path
-          description: |
-            ID of the variant on a product, or on an associated Price List Record.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -572,14 +557,6 @@ paths:
       summary: Delete a Product Variant
       description: Deletes a product *Variant*.
       operationId: deleteVariantById
-      parameters:
-        - name: variant_id
-          in: path
-          description: |
-            ID of the variant on a product, or on an associated Price List Record.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
These are already defined on the endpoint level and aren't required on the method level.

![Screenshot 2023-09-04 at 13 02 13](https://github.com/bigcommerce/api-specs/assets/553566/9f3e21f3-8893-49a3-b6ec-1b611e4491a1)


# [DEVDOCS-]

## What changed?
Provide a bulleted list in the present tense
* remove duplicate variant_id from product variants endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
