### PR TITLE
bugfix: review duplicate review id param on product reviews endpoint

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -5842,14 +5842,6 @@ paths:
       description: Returns a single *Product Review*. Optional parameters maybe passed in.
       operationId: getProductReviewById
       parameters:
-        - name: review_id
-          in: path
-          description: |
-            The ID of the `review` that is being operated on.
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -5982,13 +5974,6 @@ paths:
       operationId: updateProductReview
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: review_id
-          in: path
-          description: |
-            The ID of the `review` that is being operated on.
-          required: true
-          schema:
-            type: integer
       requestBody:
         description: |
           A BigCommerce `ProductReview` object.
@@ -6155,14 +6140,6 @@ paths:
       summary: Delete a Product Review
       description: Deletes a *Product Review*.
       operationId: deleteProductReview
-      parameters:
-        - name: review_id
-          in: path
-          description: |
-            The ID of the `review` that is being operated on.
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
param is already defined on endpoint level, not required on a method level as well.

![Uploading Screenshot 2023-09-04 at 13.15.24.png…]()

# [DEVDOCS-]
{Ticket number or summary of work}

## What changed?
Provide a bulleted list in the present tense
* remove duplicate review id param on product reviews endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
