### PR TITLE
bugfix: remove duplicate category id param on category sort order endpoint

### DIFF
--- a/reference/catalog/categories_catalog.v3.yml
+++ b/reference/catalog/categories_catalog.v3.yml
@@ -1770,13 +1770,6 @@ paths:
           - Priority 2: Manually specified sort order on Product (Global) Level (UI/API).
           - Priority 3: Default sorting by Product ID (newly added products go first) (UI/API).
       operationId: getsortorders
-      parameters:
-        - name: category_id
-          in: path
-          description: The ID of the `Category` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       responses:
         '200':
           description: ''
@@ -1799,12 +1792,6 @@ paths:
       operationId: updatesortorder
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: category_id
-          in: path
-          description: The ID of the `Category` to which the resource belongs.
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
category_id is already specified as a param on an endpoint level and is not required on method level also.

![Screenshot 2023-09-04 at 13 51 46](https://github.com/bigcommerce/api-specs/assets/553566/9a979dd9-a6b5-4e3c-9d2b-1379e655dafe)

# [DEVDOCS-]
{Ticket number or summary of work}

## What changed?
Provide a bulleted list in the present tense
* remove duplicate category id para on category sort order endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
