### PR TITLE
bugfix: remove duplicate uuid param on theme configuration endpoint.

### DIFF
--- a/reference/themes.v3.yml
+++ b/reference/themes.v3.yml
@@ -507,11 +507,6 @@ paths:
           description: Filter configurations by a variation_uuid.
     parameters:
       - $ref: '#/components/parameters/Accept'
-      - schema:
-          type: string
-        name: uuid
-        in: path
-        required: true
       - in: query
         name: 'site_id:in'
         description: Filter configurations by a list of site_ids


### PR DESCRIPTION
Already defined at endpoint level.

![Screenshot 2023-09-04 at 13 57 00](https://github.com/bigcommerce/api-specs/assets/553566/dca9ef53-08f7-4ff1-9c90-dd0f6d4c1f69)


# [DEVDOCS-]
{Ticket number or summary of work}

## What changed?
Provide a bulleted list in the present tense
* remove duplicate uuid param on theme configuration endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
