### PR TITLE
bugfix: remove duplicate video id param on product video endpoint

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -2878,13 +2878,6 @@ paths:
       description: Returns a single *Product Video*. Optional parameters can be passed in.
       operationId: getProductVideoById
       parameters:
-        - name: id
-          in: path
-          description: The BigCommerce ID of the `Video`
-          required: true
-          schema:
-            type: integer
-
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -2952,12 +2945,6 @@ paths:
       operationId: updateProductVideo
       parameters:
         - $ref: '#/components/parameters/ContentType'
-        - name: id
-          in: path
-          description: The BigCommerce ID of the `Video`
-          required: true
-          schema:
-            type: integer
       requestBody:
         content:
           application/json:
@@ -3098,13 +3085,6 @@ paths:
       summary: Delete a Product Video
       description: Deletes a *Product Video*.
       operationId: deleteProductVideo
-      parameters:
-        - name: id
-          in: path
-          description: The BigCommerce ID of the `Video`
-          required: true
-          schema:
-            type: integer
       responses:
         '204':
           description: ''


### PR DESCRIPTION
Already defined on the endpoint level.

![Screenshot 2023-09-04 at 14 07 58](https://github.com/bigcommerce/api-specs/assets/553566/04f814e2-5bfc-4709-bf14-409be2b359aa)

# [DEVDOCS-]
{Ticket number or summary of work}

## What changed?
Provide a bulleted list in the present tense
* remove duplicate video id param from product video endpoint

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
