### PR TITLE
Update Operation IDs to be consistent & programmatic

### DIFF
--- a/reference/abandoned_cart_emails.v3.yaml
+++ b/reference/abandoned_cart_emails.v3.yaml
@@ -57,11 +57,11 @@ paths:
                     meta: {}
       tags:
         - Abandoned Cart Emails
-      summary: Get all email templates
-      operationId: getAbandonedCartEmails
+      summary: Get all abandoned cart email templates
+      operationId: getAbandonedCartEmailTemplates
     post:
-      summary: Create email template
-      operationId: createEmailTemplate
+      summary: Create abandoned cart email template
+      operationId: createAbandonedCartEmailTemplate
       tags:
         - Abandoned Cart Emails
       responses:
@@ -124,11 +124,11 @@ paths:
                     $ref: '#/components/schemas/metaCollection_open'
       tags:
         - Abandoned Cart Emails
-      operationId: getAbandonedCartEmailTemplateId
+      operationId: getAbandonedCartEmailTemplate
     put:
       summary: Update an email template
       description: Update an email template.
-      operationId: updateAbandonedCartEmailsId
+      operationId: updateAbandonedCartEmailTemplate
       tags:
         - Abandoned Cart Emails
       responses:
@@ -184,7 +184,7 @@ paths:
         - Abandoned Cart Emails
       description: Delete Abandoned Cart Email template.
       summary: Delete email template
-      operationId: deleteAbandonedCartEmailTemplateId
+      operationId: deleteAbandonedCartEmailTemplate
       responses:
         '204':
           description: No Content
@@ -270,7 +270,7 @@ paths:
         - $ref: '#/components/parameters/ChannelIdRequired'
     put:
       summary: Update email template settings
-      operationId: updateEmailTemplateSettings
+      operationId: updateAbandonedCartEmailTemplateSettings
       tags:
         - Template settings
       responses:

--- a/reference/abandoned_carts.v3.yml
+++ b/reference/abandoned_carts.v3.yml
@@ -120,12 +120,6 @@ paths:
       tags:
         - Abandoned Carts Settings
       parameters:
-        - name: channel_id
-          description: The channel ID of the settings overrides
-          in: path
-          required: true
-          schema:
-            type: integer
         - $ref: '#/components/parameters/ContentType'
       requestBody:
         required: true
@@ -154,13 +148,13 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       security: []
     parameters:
-      
       - $ref: '#/components/parameters/Accept'
-      - schema:
-          type: string
-        name: channel_id
+      - name: channel_id
+        description: The channel ID of the settings overrides
         in: path
         required: true
+        schema:
+          type: integer
   '/abandoned-carts/{token}':
     get:
       responses:

--- a/reference/carts.sf.yml
+++ b/reference/carts.sf.yml
@@ -31,7 +31,7 @@ paths:
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
 
-      operationId: getACart
+      operationId: getCart
       parameters:
         - $ref: '#/components/parameters/include'
       responses:
@@ -48,7 +48,7 @@ paths:
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
 
-      operationId: createACart
+      operationId: createCart
       parameters:
         - $ref: '#/components/parameters/include'
       requestBody:
@@ -84,7 +84,7 @@ paths:
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
 
-      operationId: deleteACart
+      operationId: deleteCart
       parameters:
         - name: cartId
           in: path
@@ -293,7 +293,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: addCartCurrency
+      operationId: updateCartCurrency
       parameters:
         - name: cartId
           in: path

--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -271,7 +271,7 @@ paths:
         '201':
           $ref: '#/components/responses/CartResponse'
       summary: Create a Cart
-      operationId: createACart
+      operationId: createCart
   '/carts/{cartId}/items':
     parameters:
       - $ref: '#/components/parameters/cartId'
@@ -344,7 +344,7 @@ paths:
         '201':
           $ref: '#/components/responses/CartResponse'
       summary: Add Cart Line Items
-      operationId: addCartLineItem
+      operationId: addCartLineItems
   '/carts/{cartId}/redirect_urls':
     parameters:
       - $ref: '#/components/parameters/cartId'
@@ -554,7 +554,7 @@ paths:
         '404':
           description: Cart not found.
       summary: Get a Cart
-      operationId: getACart
+      operationId: getCart
     put:
       description: |-
         Updates a *Cartʼs* `customer_id`.
@@ -592,7 +592,7 @@ paths:
         '201':
           $ref: '#/components/responses/CartResponse'
       summary: Update Customer ID
-      operationId: updateACart
+      operationId: updateCart
     delete:
       description: Deletes a *Cart*. Once a *Cart* has been deleted it can’t be recovered.
       tags:
@@ -601,7 +601,7 @@ paths:
         '204':
           description: ''
       summary: Delete a Cart
-      operationId: deleteACart
+      operationId: deleteCart
   '/carts/settings':
     parameters: 
       - $ref: '#/components/parameters/Accept'
@@ -812,7 +812,7 @@ paths:
         Create a cart `Metafield`. 
 
         If you create an order from a Cart, you can continue referencing the Cart Metafields even if you delete the original Cart. Use the `cart_id` field on the Order to construct the Cart Metafield endpoint. 
-      operationId: CreateCartMetafieldsByCartId
+      operationId: createCartMetafield
       parameters: 
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -851,7 +851,7 @@ paths:
       tags:
         - Metafields
       description: Gets a cart metafield.
-      operationId: getACartMetafield
+      operationId: getCartMetafield
       responses:
         '200':
           description: |
@@ -888,7 +888,7 @@ paths:
         - Metafields
       description: |
         Update a `Metafield`, by `cart_id`.
-      operationId: UpdateCartMetafieldsByCartId
+      operationId: updateCartMetafield
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -928,7 +928,7 @@ paths:
         - Metafields
       description: |
         Deletes a `Metafield`.
-      operationId: deleteCartMetafieldById
+      operationId: deleteCartMetafield
       responses:
         '204':
           description: |

--- a/reference/catalog/brands_catalog.v3.yml
+++ b/reference/catalog/brands_catalog.v3.yml
@@ -959,7 +959,7 @@ paths:
         - Brands
       summary: Delete a Brand
       description: Deletes a *Brand*.
-      operationId: deleteBrandById
+      operationId: deleteBrand
       responses:
         '204':
           description: ''
@@ -973,7 +973,7 @@ paths:
         - Metafields
       summary: Get All Brand Metafields
       description: 'Returns a list of *Brand Metafields*. Optional filter parameters can be passed in. '
-      operationId: getBrandMetafieldsByBrandId
+      operationId: getBrandMetafields
       parameters:
         - name: id
           in: query
@@ -1274,7 +1274,7 @@ paths:
         - Metafields
       summary: Get a Brand Metafields
       description: Returns a *Brand Metafield*. Optional filter parameters can be passed in.
-      operationId: getBrandMetafieldByBrandId
+      operationId: getBrandMetafield
       parameters:
         - name: metafield_id
           in: path
@@ -1429,7 +1429,7 @@ paths:
         - Metafields
       summary: Delete a Brand Metafield
       description: Deletes a *Brand Metafield*.
-      operationId: deleteBrandMetafieldById
+      operationId: deleteBrandMetafield
       parameters:
         - name: metafield_id
           in: path

--- a/reference/catalog/categories_catalog.v3.yml
+++ b/reference/catalog/categories_catalog.v3.yml
@@ -728,7 +728,7 @@ paths:
         - Categories
       summary: Get a Category
       description: Returns a single *Category*. Optional parameters can be passed in.
-      operationId: getCategoryById
+      operationId: getCategory
       parameters:
         - name: include_fields
           in: query
@@ -1140,7 +1140,7 @@ paths:
         - Categories
       summary: Delete a Category
       description: Deletes a *Category*.
-      operationId: deleteCategoryById
+      operationId: deleteCategory
       responses:
         '204':
           description: ''
@@ -1154,7 +1154,7 @@ paths:
         - Metafields
       summary: Get All Category Metafields
       description: Returns a list of *Metafields* on a *Category*. Optional filter parameters can be passed in.
-      operationId: getCategoryMetafieldsByCategoryId
+      operationId: getCategoryMetafields
       parameters:
         - name: id
           in: query
@@ -1422,7 +1422,7 @@ paths:
         - Metafields
       summary: Get a Category Metafield
       description: Returns a single *Category Metafield*. Optional parameters can be passed in.
-      operationId: getCategoryMetafieldByCategoryId
+      operationId: getCategoryMetafield
       parameters:
         - name: include_fields
           in: query
@@ -1547,7 +1547,7 @@ paths:
         - Metafields
       summary: Delete a Category Metafield
       description: Deletes a *Category Metafield*.
-      operationId: deleteCategoryMetafieldById
+      operationId: deleteCategoryMetafield
       responses:
         '204':
           description: ''
@@ -1684,7 +1684,7 @@ paths:
           - Priority 1: Manually specified sort order on Category Level (API).
           - Priority 2: Manually specified sort order on Product (Global) Level (UI/API).
           - Priority 3: Default sorting by Product ID (newly added products go first) (UI/API).
-      operationId: getsortorders
+      operationId: getCategorySortOrders
       responses:
         '200':
           description: ''
@@ -1710,7 +1710,7 @@ paths:
         - Sort Order
       summary: Update Product Sort Order
       description: Updates sort order of products within a specific category.
-      operationId: updatesortorder
+      operationId: updateCategorySortOrders
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:

--- a/reference/catalog/category-trees_catalog.v3.yml
+++ b/reference/catalog/category-trees_catalog.v3.yml
@@ -463,7 +463,7 @@ paths:
     get:
       summary: Get a Category Tree
       description: Returns a *Category Tree*.
-      operationId: GetCategoryTreeByTreeId
+      operationId: GetCategoryTree
       parameters:
         - name: depth
           description: Max depth for a tree of categories.

--- a/reference/catalog/product-modifiers_catalog.v3.yml
+++ b/reference/catalog/product-modifiers_catalog.v3.yml
@@ -53,7 +53,7 @@ paths:
         - Product Modifiers
       summary: Get All Product Modifiers
       description: Returns a list of all *Product Modifiers*. Optional parameters can be passed in.
-      operationId: getModifiers
+      operationId: getProductModifiers
       parameters:
         - name: page
           in: query
@@ -157,7 +157,7 @@ paths:
 
         **Notes**
         It takes two separate requests to create a new checkbox modifier with option values. Perform a request to create a modifier, then perform a second request to update option values.
-      operationId: createModifier
+      operationId: createProductModifier
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -842,9 +842,9 @@ paths:
     get:
       tags:
         - Product Modifiers
-      summary: Get a Modifier
+      summary: Get a Product Modifier
       description: Returns a single *Product Modifier*. Optional parameters can be passed in.
-      operationId: getModifierById
+      operationId: getProductModifier
       parameters:
         - name: include_fields
           in: query
@@ -893,9 +893,9 @@ paths:
     put:
       tags:
         - Product Modifiers
-      summary: Update a Modifier
+      summary: Update a Product Modifier
       description: Updates a *Product Modifier*.
-      operationId: updateModifier
+      operationId: updateProductModifier
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -1468,9 +1468,9 @@ paths:
     delete:
       tags:
         - Product Modifiers
-      summary: Delete a Modifier
+      summary: Delete a Product Modifier
       description: Deletes a *Product Modifier*.
-      operationId: deleteModifierById
+      operationId: deleteProductModifier
       responses:
         '204':
           description: ''
@@ -1483,9 +1483,9 @@ paths:
     get:
       tags:
         - Values
-      summary: Get All Modifier Values
+      summary: Get All Product Modifier Values
       description: Returns a list of all product *Modifier Values*. Optional parameters can be passed in.
-      operationId: getModifierValues
+      operationId: getProductModifierValues
       parameters:
         - name: modifier_id
           in: path
@@ -1575,7 +1575,7 @@ paths:
     post:
       tags:
         - Values
-      summary: Create Modifier Value
+      summary: Create Product Modifier Value
       description: |-
         Creates a *Modifier Value*.
 
@@ -1585,7 +1585,7 @@ paths:
 
         **Read-Only Fields**
         * id
-      operationId: createModifierValue
+      operationId: createProductModifierValue
       parameters:
         - $ref: '#/components/parameters/ContentType'
         - name: modifier_id
@@ -1863,9 +1863,9 @@ paths:
     get:
       tags:
         - Values
-      summary: Get a Modifier Value
+      summary: Get a Product Modifier Value
       description: Returns a single *Modifier Value*. Optional parameters can be passed in.
-      operationId: getModifierValueById
+      operationId: getProductModifierValue
       parameters:
         - name: modifier_id
           in: path
@@ -1949,7 +1949,7 @@ paths:
     put:
       tags:
         - Values
-      summary: Update a Modifier Value
+      summary: Update a Product Modifier Value
       description: |-
         Updates a *Modifier Value*.
 
@@ -1958,7 +1958,7 @@ paths:
 
         **Read-Only Fields**
         * id
-      operationId: updateModifierValue
+      operationId: updateProductModifierValue
       parameters:
         - $ref: '#/components/parameters/ContentType'
         - name: modifier_id
@@ -2246,9 +2246,9 @@ paths:
     delete:
       tags:
         - Values
-      summary: Delete Modifier Value
+      summary: Delete Product Modifier Value
       description: Deletes a *Modifier Value*.
-      operationId: deleteModifierValueById
+      operationId: deleteProductModifierValue
       parameters:
         - name: modifier_id
           in: path
@@ -2277,7 +2277,7 @@ paths:
     post:
       tags:
         - Images
-      summary: Create Modifier Image
+      summary: Create Product Modifier Image
       description: |-
         Creates a *Modifier Image*.
 
@@ -2285,7 +2285,7 @@ paths:
 
          **Required Fields**
         - image_file: Form posts are the only accepted upload option.
-      operationId: createModifierImage
+      operationId: createProductModifierImage
       parameters:
         - $ref: '#/components/parameters/ContentType'
         - name: modifier_id

--- a/reference/catalog/product-variant-options_catalog.v3.yml
+++ b/reference/catalog/product-variant-options_catalog.v3.yml
@@ -59,7 +59,7 @@ paths:
         - Product Variant Options
       summary: Get All Product Variant Options
       description: 'Returns a list of product *Variant Options*. Optional parameters can be passed in. '
-      operationId: getOptions
+      operationId: getProductVariantOptions
       parameters:
         - name: page
           in: query
@@ -142,7 +142,7 @@ paths:
         * There are several examples listed below that create options, but the SKUs are not updated and they are not a variant on the product. Variant SKUs must be created with a separate request.
         * Variant options will show on the storefront as an option that can be selected by the customer. A request like this could be used to add new choices to a variant that has already been created.
         * If more than one variant needs to be created, use the [Create a Product](/docs/rest-catalog/products#create-a-product) endpoint.
-      operationId: createOption
+      operationId: createProductVariantOption
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -794,7 +794,7 @@ paths:
         - Product Variant Options
       summary: Get a Product Variant Option
       description: Returns a single *Variant Option*. Optional parameters can be passed in.
-      operationId: getOptionById
+      operationId: getProductVariantOption
       parameters:
         - name: include_fields
           in: query
@@ -849,7 +849,7 @@ paths:
 
         **Read-Only Fields**
         * id
-      operationId: updateOption
+      operationId: updateProductVariantOption
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -1459,7 +1459,7 @@ paths:
         - Product Variant Options
       summary: Delete a Product Variant Option
       description: Deletes a *Variant Option*.
-      operationId: deleteOptionById
+      operationId: deleteProductVariantOption
       responses:
         '204':
           description: ''
@@ -1474,7 +1474,7 @@ paths:
         - Values
       summary: Get All Product Variant Option Values
       description: Returns a list of all *Variant Option Values*. Optional parameters can be passed in.
-      operationId: getOptionValues
+      operationId: getProductVariantOptionValues
       parameters:
         - name: option_id
           in: path
@@ -1617,7 +1617,7 @@ paths:
 
         **Limits**
         * 250 option values per option limit.
-      operationId: createOptionValue
+      operationId: createProductVariantOptionValue
       parameters:
         - $ref: '#/components/parameters/ContentType'
         - name: option_id
@@ -1769,7 +1769,7 @@ paths:
         - Values
       summary: Get a Product Variant Option Value
       description: Returns a single *Variant Option Value*. Optional parameters can be passed in.
-      operationId: getOptionValueById
+      operationId: getProductVariantOptionValue
       parameters:
         - name: option_id
           in: path
@@ -1890,7 +1890,7 @@ paths:
 
         **Read-Only Fields**
         * id
-      operationId: updateOptionValue
+      operationId: updateProductVariantOptionValue
       parameters:
         - $ref: '#/components/parameters/ContentType'
         - name: option_id
@@ -2057,7 +2057,7 @@ paths:
         - Values
       summary: Delete a Product Variant Option Value
       description: Deletes a *Variant Option Value*.
-      operationId: deleteOptionValueById
+      operationId: deleteProductVariantOptionValue
       parameters:
         - name: option_id
           in: path

--- a/reference/catalog/product-variants_catalog.v3.yml
+++ b/reference/catalog/product-variants_catalog.v3.yml
@@ -58,7 +58,7 @@ paths:
         - Product Variants
       summary: Get All Product Variants
       description: Returns a list of product *Variants*. Optional parameters can be passed in.
-      operationId: getVariantsByProductId
+      operationId: getProductVariants
       parameters:
         - name: page
           in: query
@@ -239,7 +239,7 @@ paths:
         * 255 characters SKU length limit.
 
         Variants need to be created one at a time using this endpoint. To use a variant array and create products and variants in the same call use the [Create Products](/docs/rest-catalog/products#create-a-product) during the initial product creation.
-      operationId: createVariant
+      operationId: createProductVariant
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -377,7 +377,7 @@ paths:
         - Product Variants
       summary: Get a Product Variant
       description: Returns a single product *Variant*. Optional parameters can be passed in.
-      operationId: getVariantById
+      operationId: getProductVariant
       parameters:
         - name: include_fields
           in: query
@@ -462,7 +462,7 @@ paths:
         - Product Variants
       summary: Update a Product Variant
       description: Updates a product *Variant*.
-      operationId: updateVariant
+      operationId: updateProductVariant
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -556,7 +556,7 @@ paths:
         - Product Variants
       summary: Delete a Product Variant
       description: Deletes a product *Variant*.
-      operationId: deleteVariantById
+      operationId: deleteProductVariant
       responses:
         '204':
           description: ''
@@ -571,7 +571,7 @@ paths:
         - Metafields
       summary: Get All Product Variant Metafields
       description: Returns a list of product variant *Metafields*. Optional parameters can be passed in.
-      operationId: getVariantMetafieldsByProductIdAndVariantId
+      operationId: getProductVariantMetafields
       parameters:
         - name: variant_id
           in: path
@@ -665,7 +665,7 @@ paths:
         * id
 
         **Note:** The maxiumum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID. For more information, see [Platform Limits](https://support.bigcommerce.com/s/article/Platform-Limits) in the Help Center.
-      operationId: createVariantMetafield
+      operationId: createProductVariantMetafield
       parameters:
         - $ref: '#/components/parameters/ContentType'
         - name: variant_id
@@ -770,7 +770,7 @@ paths:
         - Metafields
       summary: Get a Product Variant Metafields
       description: Returns a single product variant *Metafield*. Optional parameters can be passed in.
-      operationId: getVariantMetafieldByProductIdAndVariantId
+      operationId: getProductVariantMetafield
       parameters:
         - name: include_fields
           in: query
@@ -834,7 +834,7 @@ paths:
         - Metafields
       summary: Update Product Variant Metafields
       description: "Updates a product variant *Metafield*.\n\n**Required Fields:**\n* none\n\n**Read-Only Fields**\n* id\n* These fields can only be modified by the app (API credentials) that created the metafield:\n\t* namespace\n\t* key\n\t* permission_set\n\n**Usage Notes**\n* Attempting to modify `namespace`, `key`, and `permission_set` fields using a client ID different from the one used to create those metafields will result in a 403 error message. "
-      operationId: updateVariantMetafield
+      operationId: updateProductVariantMetafield
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -894,9 +894,9 @@ paths:
     delete:
       tags:
         - Metafields
-      summary: Delete a Variant Metafield
+      summary: Delete a Product Variant Metafield
       description: Deletes a product variant *Metafield*.
-      operationId: deleteVariantMetafieldById
+      operationId: deleteProductVariantMetafield
       responses:
         '204':
           description: ''
@@ -910,7 +910,7 @@ paths:
     post:
       tags:
         - Images
-      summary: Create a Variant Image
+      summary: Create a Product Variant Image
       description: |-
         Creates a *Variant Image*.
 
@@ -921,7 +921,7 @@ paths:
          **Required Fields**
         - image_file: Form posts. Files larger than 1 MB are not accepted
         - image_url: Any publicly available URL
-      operationId: createVariantImage
+      operationId: createProductVariantImage
       parameters:
         - $ref: '#/components/parameters/ContentType'
         - name: variant_id

--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -1342,7 +1342,7 @@ paths:
         - Products
       summary: Get a Product
       description: Returns a single *Product*. Optional parameters can be passed in.
-      operationId: getProductById
+      operationId: getProduct
       parameters:
         - name: include
           in: query
@@ -1859,7 +1859,7 @@ paths:
         - Products
       summary: Delete a Product
       description: Deletes a *Product*.
-      operationId: deleteProductById
+      operationId: deleteProduct
       responses:
         '204':
           description: ''
@@ -2332,7 +2332,7 @@ paths:
         - Images
       summary: Get a Product Image
       description: Returns a single *Product Image*. Optional parameters can be passed in.
-      operationId: getProductImageById
+      operationId: getProductImage
       parameters:
         - name: include_fields
           in: query
@@ -2853,7 +2853,7 @@ paths:
         - Videos
       summary: Get a Product Video
       description: Returns a single *Product Video*. Optional parameters can be passed in.
-      operationId: getProductVideoById
+      operationId: getProductVideo
       parameters:
         - name: include_fields
           in: query
@@ -3076,7 +3076,7 @@ paths:
         - Complex Rules
       summary: Get Complex Rules
       description: Returns a list of all product *Complex Rules*. Optional parameters may be passed in.
-      operationId: getComplexRules
+      operationId: getProductComplexRules
       parameters:
         - name: include_fields
           in: query
@@ -3181,7 +3181,7 @@ paths:
         - rule_id
         - combination_id
         - id
-      operationId: createComplexRule
+      operationId: createProductComplexRule
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -3516,9 +3516,9 @@ paths:
     get:
       tags:
         - Complex Rules
-      summary: Get a Complex Rule
+      summary: Get a Product Complex Rule
       description: Returns a single *Complex Rule*. Optional parameters can be passed in.
-      operationId: getComplexRuleById
+      operationId: getProductComplexRule
       parameters:
         - name: include_fields
           in: query
@@ -3697,7 +3697,7 @@ paths:
     put:
       tags:
         - Complex Rules
-      summary: Update a Complex Rule
+      summary: Update a Product Complex Rule
       description: |-
         Updates a *Complex Rule*.
 
@@ -3710,7 +3710,7 @@ paths:
         - rule_id
         - combination_id
         - id
-      operationId: updateComplexRule
+      operationId: updateProductComplexRule
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -4033,9 +4033,9 @@ paths:
     delete:
       tags:
         - Complex Rules
-      summary: Delete a Complex Rule
+      summary: Delete a Product Complex Rule
       description: Deletes a product *Complex Rule*.
-      operationId: deleteComplexRuleById
+      operationId: deleteProductComplexRule
       responses:
         '204':
           description: ''
@@ -4048,9 +4048,9 @@ paths:
     get:
       tags:
         - Custom Fields
-      summary: Get Custom Fields
+      summary: Get Product Custom Fields
       description: Returns a list of product *Custom Fields*. Optional parameters can be passed in.
-      operationId: getCustomFields
+      operationId: getProductCustomFields
       parameters:
         - name: include_fields
           in: query
@@ -4136,7 +4136,7 @@ paths:
     post:
       tags:
         - Custom Fields
-      summary: Create a Custom Fields
+      summary: Create a Product Custom Field
       description: |-
         Creates a *Custom Field*.
 
@@ -4150,7 +4150,7 @@ paths:
         **Limits**
         - 200 custom fields per product limit.
         - 255 characters per custom field limit.
-      operationId: createCustomField
+      operationId: createProductCustomField
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -4287,9 +4287,9 @@ paths:
     get:
       tags:
         - Custom Fields
-      summary: Get a Custom Field
+      summary: Get a Product Custom Field
       description: Returns a single *Custom Field*. Optional parameters can be passed in.
-      operationId: getCustomFieldById
+      operationId: getProductCustomField
       parameters:
         - name: include_fields
           in: query
@@ -4343,7 +4343,7 @@ paths:
     put:
       tags:
         - Custom Fields
-      summary: Update a Custom Field
+      summary: Update a Product Custom Field
       description: |-
         Updates a *Custom Field*.
 
@@ -4352,7 +4352,7 @@ paths:
 
         **Read-Only**
         - id
-      operationId: updateCustomField
+      operationId: updateProductCustomField
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -4492,9 +4492,9 @@ paths:
     delete:
       tags:
         - Custom Fields
-      summary: Delete a Custom Field
+      summary: Delete a Product Custom Field
       description: Deletes a product *Custom Field*.
-      operationId: deleteCustomFieldById
+      operationId: deleteProductCustomField
       responses:
         '204':
           description: '`204 No Content`. Action has been enacted and no further information is to be supplied. `null` is returned.'
@@ -4768,7 +4768,7 @@ paths:
         - Bulk Pricing Rules
       summary: Get a Bulk Pricing Rule
       description: Returns a single *Bulk Pricing Rule*. Optional parameters can be passed in.
-      operationId: getBulkPricingRuleById
+      operationId: getBulkPricingRule
       parameters:
         - name: include_fields
           in: query
@@ -5006,7 +5006,7 @@ paths:
         - Bulk Pricing Rules
       summary: Delete a Bulk Pricing Rule
       description: Deletes a *Bulk Pricing Rule*.
-      operationId: deleteBulkPricingRuleById
+      operationId: deleteBulkPricingRule
       responses:
         '204':
           description: ''
@@ -5042,7 +5042,7 @@ paths:
         - Metafields
       summary: Get All Product Metafields
       description: Returns a list of *Product Metafields*. Optional parameters can be passed in.
-      operationId: getProductMetafieldsByProductId
+      operationId: getProductMetafields
       parameters:
         - name: page
           in: query
@@ -5252,7 +5252,7 @@ paths:
         - Metafields
       summary: Get a Product Metafield
       description: Returns a single *Product Metafield*. Optional parameters can be passed in.
-      operationId: getProductMetafieldByProductId
+      operationId: getProductMetafield
       parameters:
         - name: include_fields
           in: query
@@ -5378,7 +5378,7 @@ paths:
         - Metafields
       summary: Delete a Product Metafield
       description: Deletes a *Product Metafield*.
-      operationId: deleteProductMetafieldById
+      operationId: deleteProductMetafield
       responses:
         '204':
           description: ''
@@ -5704,7 +5704,7 @@ paths:
         - Reviews
       summary: Get a Product Review
       description: Returns a single *Product Review*. Optional parameters maybe passed in.
-      operationId: getProductReviewById
+      operationId: getProductReview
       parameters:
         - name: include_fields
           in: query

--- a/reference/channels.v3.yml
+++ b/reference/channels.v3.yml
@@ -110,7 +110,7 @@ paths:
       tags:
         - Channels
       summary: Get All Channels
-      operationId: listChannels
+      operationId: getChannels
       description: |-
         Returns a list of *Channels*.
 
@@ -240,7 +240,7 @@ paths:
       tags:
         - Channel Currency Assignments
       summary: Get All Channels Currency Assignments
-      operationId: listAllCurrencyAssignments
+      operationId: getAllCurrencyAssignments
       description: Returns a list of currency assignments for all channels.
       responses:
         '200':
@@ -367,7 +367,7 @@ paths:
       tags:
         - Channel Listings
       summary: Get Channel Listings
-      operationId: listChannelListings
+      operationId: getChannelListings
       description: 'Returns a list of all *Channel Listings* for a specific channel. Note that if the *Channel* is not found or there is no listing associated to the *Channel*, it will return a 200 response with empty data.'
       parameters:
         - $ref: '#/components/parameters/limit'
@@ -468,7 +468,7 @@ paths:
       tags:
         - Channel Site Checkout Url
       description: Creates or updates (upserts) a site's checkout URL
-      operationId: putCheckoutUrl
+      operationId: updateCheckoutUrl
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -542,7 +542,7 @@ paths:
                     type: object
     delete:
       summary: Delete a Site's Checkout URL
-      operationId: delete-checkout-url
+      operationId: deleteCheckoutUrl
       description: Deletes a siteʼs checkout URL. After deletion, a shared checkout URL is used.
       tags:
         - Channel Site Checkout Url
@@ -569,7 +569,7 @@ paths:
         Alias of `GET /sites?channel_id=channel_id`
 
         Returns site data for the specified channel.
-      operationId: get-channel-site
+      operationId: getChannelSite
       responses:
         '200':
           $ref: '#/components/responses/site_Resp'
@@ -582,7 +582,7 @@ paths:
       summary: Update a Channel Site
       parameters:
         - $ref: '#/components/parameters/ContentType'
-      operationId: put-channel-site
+      operationId: updateChannelSite
       requestBody:
         content:
           application/json:
@@ -601,7 +601,7 @@ paths:
       summary: Create a Channel Site
       parameters:
         - $ref: '#/components/parameters/ContentType'
-      operationId: postChannelSite
+      operationId: createChannelSite
       requestBody:
         content:
           application/json:
@@ -624,7 +624,7 @@ paths:
                 type: object
                 properties: {}
       description: Deletes the Channel's site.
-      operationId: DeleteChannelSite
+      operationId: deleteChannelSite
       tags:
         - Channel Site
       summary: Delete a Channel Site
@@ -636,7 +636,7 @@ paths:
       summary: Get Channel Menus
       description: |
         Returns list of Control Panel side navigation menus for a channel.
-      operationId: get-channel-menus
+      operationId: getChannelMenus
       responses:
         '200':
           $ref: '#/components/responses/channel_menus_Resp'
@@ -647,7 +647,7 @@ paths:
         '200':
           $ref: '#/components/responses/channel_menus_Resp'
       summary: Create Channel Menus
-      operationId: postChannelMenus
+      operationId: createChannelMenus
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -677,7 +677,7 @@ paths:
                     data: 1
                     meta: {}
       description: Deletes control panel side navigation menus for a channel.
-      operationId: DeleteChannelMenus
+      operationId: deleteChannelMenus
       tags:
         - Channel Menus
       summary: Delete Channel Menus
@@ -692,7 +692,7 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/metafield_200'
-      operationId: get-channels-channel_id-metafields
+      operationId: getChannelMetafields
       parameters:
         - $ref: '#/components/parameters/PageParam'
         - $ref: '#/components/parameters/LimitParam'
@@ -704,7 +704,7 @@ paths:
       summary: Create a Channel Metafield
       parameters:
         - $ref: '#/components/parameters/ContentType'
-      operationId: post-channels-channel_id-metafields
+      operationId: createChannelMetafield
       responses:
         '200':
           $ref: '#/components/responses/metafield_200'
@@ -736,13 +736,13 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/metafield_200'
-      operationId: get-channels-channel_id-metafields-metafield_id
+      operationId: getChannelMetafield
       description: Returns a single channel metafield.
     put:
       summary: Update a Channel Metafield
       parameters:
         - $ref: '#/components/parameters/ContentType'
-      operationId: put-channels-channel_id-metafields-metafield_id
+      operationId: updateChannelMetafield
       responses:
         '200':
           $ref: '#/components/responses/metafield_200'
@@ -760,7 +760,7 @@ paths:
         * Attempting to modify `namespace`, `key`, and `permission_set` fields using a client ID different from the one used to create those metafields will result in a `403` error message. 
     delete:
       summary: Delete a Channel Metafield
-      operationId: delete-channels-channel_id-metafields-metafield_id
+      operationId: deleteChannelMetafield
       responses:
         '204':
           description: No Content

--- a/reference/checkouts.sf.yml
+++ b/reference/checkouts.sf.yml
@@ -43,7 +43,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsByCheckoutIdGet
+      operationId: getCheckout
       parameters:
         - name: checkoutId
           in: path
@@ -235,7 +235,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsByCheckoutIdPut
+      operationId: updateCheckout
       parameters:
         - name: checkoutId
           in: path
@@ -378,7 +378,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsCartsItemsItemIdByCheckoutIdAndCartIdPut
+      operationId: updateCheckoutLineItem
       parameters:
         - name: checkoutId
           in: path
@@ -529,7 +529,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsCartsItemsItemIdByCheckoutIdAndCartIdDelete
+      operationId: deleteCheckoutLineItem
       parameters:
         - name: checkoutId
           in: path
@@ -786,7 +786,7 @@ paths:
         > * Sending `email` property as a payload in POST request triggers the abandoned cart notification process.
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsBillingAddressByCheckoutIdPost
+      operationId: addCheckoutBillingAddress
       parameters:
         - name: checkoutId
           in: path
@@ -933,7 +933,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsBillingAddressByCheckoutIdAndAddressIdPut
+      operationId: updateCheckoutBillingAddress
       parameters:
         - name: checkoutId
           in: path
@@ -1216,7 +1216,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsConsignmentsByCheckoutIdPost
+      operationId: createCheckoutConsignment
       parameters:
         - name: checkoutId
           in: path
@@ -1385,7 +1385,7 @@ paths:
         > * You cannot pass both an `address` and a `shippingOptionId` because the shipping option may not be available for the new address 
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsConsignmentsByCheckoutIdAndConsignmentIdPut
+      operationId: updateCheckoutConsignment
       parameters:
         - name: checkoutId
           in: path
@@ -1536,7 +1536,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsConsignmentsByCheckoutIdAndConsignmentIdDelete
+      operationId: deleteCheckoutConsignment
       parameters:
         - name: checkoutId
           in: path
@@ -1678,7 +1678,7 @@ paths:
         > * The rate limit is 20/hour (only for unique gift-certificate codes).
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsGiftCertificatesByCheckoutIdPost
+      operationId: addCheckoutGiftCertificate
       parameters:
         - name: checkoutId
           in: path
@@ -1827,7 +1827,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsGiftCertificatesByCheckoutIdAndGiftCertificateCodeDelete
+      operationId: deleteCheckoutGiftCertificate
       parameters:
         - name: checkoutId
           in: path
@@ -1860,7 +1860,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsCouponsByCheckoutIdPost
+      operationId: addCheckoutCoupon
       parameters:
         - name: checkoutId
           in: path
@@ -2006,7 +2006,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsCouponsByCheckoutIdAndCouponCodeDelete
+      operationId: deleteCheckoutCoupon
       parameters:
         - name: checkoutId
           in: path
@@ -2249,7 +2249,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.
-      operationId: CheckoutStoreCreditAdd
+      operationId: addCheckoutStoreCredit
       parameters:
         - name: checkoutId
           in: path
@@ -2273,7 +2273,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.  
-      operationId: CheckoutsStoreCreditRemove
+      operationId: removeCheckoutStoreCredit
       parameters:
         - name: checkoutId
           in: path

--- a/reference/checkouts.v3.yml
+++ b/reference/checkouts.v3.yml
@@ -44,7 +44,7 @@ paths:
         **Notes**
 
         The cart ID and checkout ID are the same.
-      operationId: CheckoutsByCheckoutIdGet
+      operationId: getCheckout
       parameters:
         - name: include
           in: query
@@ -840,7 +840,7 @@ paths:
 
         **Limits:**
         * 2000 characters for customer message
-      operationId: CheckoutsByCheckoutIdPut
+      operationId: updateCheckout
       parameters:
         - $ref: '#/components/parameters/Content-Type'
       requestBody:
@@ -1613,7 +1613,7 @@ paths:
 
         Required Fields
         * discounted_amount
-      operationId: post-store_hash-v3-checkouts-checkoutId-discounts
+      operationId: addCheckoutDiscount
       parameters:
         - $ref: '#/components/parameters/checkoutId'
         - $ref: '#/components/parameters/Accept'
@@ -2395,7 +2395,7 @@ paths:
         **Required Fields**
         * email
         * country_code
-      operationId: CheckoutsBillingAddressByCheckoutIdPost
+      operationId: addCheckoutBillingAddress
       parameters:
         - $ref: '#/components/parameters/checkoutId'
         - $ref: '#/components/parameters/Accept'
@@ -3161,7 +3161,7 @@ paths:
         - Checkout Billing Address
       summary: Update Checkout Billing Address
       description: Updates an existing billing address on a checkout.
-      operationId: CheckoutsBillingAddressByCheckoutIdAndAddressIdPut
+      operationId: updateCheckoutBillingAddress
       parameters:
         - $ref: '#/components/parameters/checkoutId'
         - $ref: '#/components/parameters/Accept'
@@ -3949,7 +3949,7 @@ paths:
 
         * `postal_code`
         * `state_or_province`
-      operationId: CheckoutsConsignmentsByCheckoutIdPost
+      operationId: addCheckoutConsignment
       parameters:
         - $ref: '#/components/parameters/checkoutId'
         - $ref: '#/components/parameters/Accept'
@@ -4737,7 +4737,7 @@ paths:
         1. Add a new [consignment](/docs/rest-management/checkouts/checkout-consignments#add-consignment-to-checkout) to a checkout. 
         
         2. Assign a shipping option to the new consignment by sending a `PUT` request to update the consignment's `shipping_option_id` with a returned value from `data.consignments[N].available_shipping_option[N].id` obtained in Step One. 
-      operationId: CheckoutsConsignmentsByCheckoutIdAndConsignmentIdPut
+      operationId: updateCheckoutConsignment
       parameters:
         - $ref: '#/components/parameters/Content-Type'
         - name: include
@@ -5510,7 +5510,7 @@ paths:
         Removes an existing consignment from a checkout.
 
         Removing the last consignment will remove the cart from the customer it is assigned to. Create a new redirect URL for the customer so they can access the cart again.
-      operationId: CheckoutsConsignmentsByCheckoutIdAndConsignmentIdDelete
+      operationId: deleteCheckoutConsignment
       responses:
         '200':
           description: ''
@@ -6266,7 +6266,7 @@ paths:
 
         **Limits**
         * Coupon codes have a 50-character limit. 
-      operationId: CheckoutsCouponsByCheckoutIdPost
+      operationId: addCheckoutCoupon
       parameters:
         - $ref: '#/components/parameters/checkoutId'
         - $ref: '#/components/parameters/Accept'
@@ -7032,7 +7032,7 @@ paths:
         - Checkout Coupons
       summary: Delete Checkout Coupon
       description: Deletes a coupon code from a checkout.
-      operationId: CheckoutsCouponsByCheckoutIdAndCouponCodeDelete
+      operationId: deleteCheckoutCoupon
       parameters:
         - $ref: '#/components/parameters/checkoutId'
         - $ref: '#/components/parameters/Accept'
@@ -7606,7 +7606,7 @@ paths:
         * Order duplication copies the existing order, assigns a new order number, and sets the new order status to `incomplete`.
         * Once the order is paid, the cart is deleted.
         * Cart deletion occurs if you are using BigCommerce to accept payments on orders.
-      operationId: createAnOrder
+      operationId: createOrder
       parameters:
         - $ref: '#/components/parameters/checkoutId'
         - $ref: '#/components/parameters/Accept'
@@ -7635,7 +7635,7 @@ paths:
         - Checkout Settings
       summary: Get Checkout Settings
       description: Get checkout settings
-      operationId: GetCheckoutSettings
+      operationId: getCheckoutSettings
       responses:
         '200':
           description: ''
@@ -7667,7 +7667,7 @@ paths:
         - Checkout Settings
       summary: Update Checkout Settings
       description: Update checkout settings
-      operationId: UpdateCheckoutSettings
+      operationId: updateCheckoutSettings
       parameters:
         - $ref: '#/components/parameters/Content-Type'
       requestBody:
@@ -7711,7 +7711,7 @@ paths:
       tags:
         - Checkout Token
       summary: Create Checkout Token
-      operationId: checkout-token
+      operationId: createCheckoutToken
       parameters:
         - $ref: '#/components/parameters/Content-Type'
       responses:

--- a/reference/consent.sf.yml
+++ b/reference/consent.sf.yml
@@ -57,7 +57,7 @@ paths:
 
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
-      operationId: postConsent
+      operationId: postCookieConsent
     parameters: []
 components:
   schemas:

--- a/reference/currencies.v2.yml
+++ b/reference/currencies.v2.yml
@@ -58,7 +58,7 @@ paths:
         - Currencies (Bulk)
       summary: Get All Currencies
       description: Returns a list of all store *Currency*.
-      operationId: getAllCurrencies
+      operationId: getCurrencies
       parameters:
         - name: page
           description: |
@@ -89,7 +89,7 @@ paths:
       tags:
         - Currencies (Bulk)
       summary: Create a Currency
-      operationId: createACurrency
+      operationId: createCurrency
       description: |-
         Creates *Currency*.
 
@@ -130,7 +130,7 @@ paths:
       tags:
         - Currencies (Bulk)
       summary: Delete All Currencies
-      operationId: deleteAllCurrencies
+      operationId: deleteCurrencies
       description: Deletes all non-default store currencies.
       responses:
         '204':
@@ -153,7 +153,7 @@ paths:
         - Currencies (Single)
       summary: Get a Currency
       description: Returns a single *Currency*.
-      operationId: getACurrency
+      operationId: getCurrency
       responses:
         '200':
           description: ""
@@ -177,7 +177,7 @@ paths:
 
 
         The `is_default` property can only be set to true. The value of `is_default` cannot be unset, only overridden. 
-      operationId: updateACurrency
+      operationId: updateCurrency
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -202,7 +202,7 @@ paths:
         Deletes a *Currency*.
 
         If a currencyʼs `is_default` property is set to true, this currency cannot be deleted. 
-      operationId: deleteACurrency
+      operationId: deleteCurrency
       responses:
         '204':
           description: ""

--- a/reference/custom-template-associations.v3.yml
+++ b/reference/custom-template-associations.v3.yml
@@ -211,7 +211,7 @@ paths:
           name: is_valid
           description: Optional toggle to filter for exclusively valid or invalid associations entries. An invalid entry is one where its file name does not match up to an existing custom layout file in the currently active theme for the channel.
       description: Get a collection of the storeʼs custom template associations across all storefronts
-      operationId: GetCustomTemplateAssociations
+      operationId: getCustomTemplateAssociations
     put:
       summary: Upsert Custom Template Associations
       tags:
@@ -256,7 +256,7 @@ paths:
                     file_name: custom-page.html
         description: ''
       description: 'Upsert new custom template associations data across all storefronts. If an existing record is found for the combination of channel ID, entity ID, and type, the existing record will be overwritten with the new template.'
-      operationId: UpsertCustomTemplateAssociations
+      operationId: upsertCustomTemplateAssociations
     delete:
       summary: Delete Custom Template Associations
       tags:
@@ -291,7 +291,7 @@ paths:
           name: type
           description: Filter associations by type
       description: Delete custom template associations. At least one query parameter must be used.
-      operationId: DeleteCustomTemplateAssociations
+      operationId: deleteCustomTemplateAssociations
 components:
   schemas:
     Error:

--- a/reference/customers.sf.yml
+++ b/reference/customers.sf.yml
@@ -39,7 +39,7 @@ paths:
         '429':
           description: Spam Protection Failed.
       summary: Create a Customer
-      operationId: createACustomer
+      operationId: createCustomer
       requestBody:
         content:
           application/json:

--- a/reference/customers.v2.yml
+++ b/reference/customers.v2.yml
@@ -57,7 +57,7 @@ paths:
         - Customers
       summary: Get All Customers
       description: Returns a list of all *Customers*. Default sorting is by `customer_ID`, from lowest to highest. Optional parameters can be passed in.
-      operationId: getAllCustomers
+      operationId: getCustomers
       parameters:
         - name: first_name
           in: query
@@ -173,7 +173,7 @@ paths:
             }
         }
         ```
-      operationId: createANewCustomer
+      operationId: createCustomer
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -220,7 +220,7 @@ paths:
         - Customers
       summary: Delete Customers
       description: By default, it deletes all *Customers*. Up to 100 customers per batch can be deleted.
-      operationId: deleteAllCustomers
+      operationId: deleteCustomers
       responses:
         '204':
           description: ''
@@ -260,7 +260,7 @@ paths:
         - Customers
       summary: Get a Customer
       description: Returns a single *Customer*.
-      operationId: getACustomer
+      operationId: getCustomer
       responses:
         '200':
           description: ''
@@ -318,7 +318,7 @@ paths:
             }
         }
         ```
-      operationId: updateACustomer
+      operationId: updateCustomer
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -442,7 +442,7 @@ paths:
         - Customers
       summary: Delete a Customer
       description: Deletes a *Customer*.
-      operationId: deleteACustomer
+      operationId: deleteCustomer
       responses:
         '204':
           description: ''
@@ -456,7 +456,7 @@ paths:
         - Customers
       summary: Get a Count of Customers
       description: Returns a count of all *Customers*.
-      operationId: getACountOfCustomers
+      operationId: getCustomersCount
       responses:
         '200':
           description: ''
@@ -553,7 +553,7 @@ paths:
       description: |-
         Returns a list of *Customer Addresses*. Returns the addresses belonging to a customer. Default sorting is by address id, from lowest to highest. 
         The maximum limit is 250. If a limit isn’t provided, up to 50 `customer_addresses` are returned by default.
-      operationId: getAllCustomerAddresses
+      operationId: getCustomerAddresses
       parameters:
         - name: page
           in: query
@@ -599,7 +599,7 @@ paths:
         **Read Only Fields**
         *   id
         *   country_iso2
-      operationId: createACustomerAddress
+      operationId: createCustomerAddress
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -621,7 +621,7 @@ paths:
         - Customer Addresses
       summary: Delete Customer Address
       description: 'By default, it deletes all *Customer Addresses*.'
-      operationId: deleteAllCustomerAddresses
+      operationId: deleteCustomerAddresses
       parameters:
         - name: page
           in: query
@@ -652,7 +652,7 @@ paths:
         - Customer Addresses
       summary: Get a Customer Address
       description: Returns a *Customer Address*.
-      operationId: getACustomerAddress
+      operationId: getCustomerAddress
       parameters:
         - name: page
           in: query
@@ -686,7 +686,7 @@ paths:
         **Read Only Fields**
         *   id
         *   country_iso2
-      operationId: updateACustomerAddress
+      operationId: updateCustomerAddress
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -792,7 +792,7 @@ paths:
         - Customer Addresses
       summary: Delete a Customer Address
       description: Deletes a *Customer Address*.
-      operationId: deletesACustomerAddress
+      operationId: deletesCustomerAddress
       responses:
         '204':
           description: ''
@@ -807,7 +807,7 @@ paths:
         - Customer Addresses
       summary: Get a Count of Customer Addresses
       description: Returns a count of addresses for a customer.
-      operationId: getACountofCustomerAddresses
+      operationId: getCustomerAddressesCount
       parameters:
         - name: page
           in: query
@@ -841,7 +841,7 @@ paths:
         - Customer Groups
       summary: Get All Customer Groups
       description: Returns a list of *Customer Groups*. Default sorting is by customer-group ID, from lowest to highest.
-      operationId: getAllCustomerGroups
+      operationId: getCustomerGroups
       parameters:
         - name: page
           in: query
@@ -930,7 +930,7 @@ paths:
 
         **Required Fields**
         * name
-      operationId: createACustomerGroup
+      operationId: createCustomerGroup
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -966,7 +966,7 @@ paths:
       description: |-
         By default, it deletes all *Customer Groups*. 
         All existing customers are unassigned from the group when it is deleted.
-      operationId: deleteAllCustomerGroups
+      operationId: deleteCustomerGroups
       responses:
         '204':
           description: ''
@@ -980,7 +980,7 @@ paths:
         - Customer Groups
       summary: Get a Customer Group
       description: Returns a *Customer Group*.
-      operationId: getACustomerGroup
+      operationId: getCustomerGroup
       parameters:
         - name: page
           in: query
@@ -1064,7 +1064,7 @@ paths:
         **Notes**
 
         Any combination of fields can be updated at once. Discount rules are treated in bulk. The entire set of rules is overwritten when a request is sent.
-      operationId: updateACustomerGroup
+      operationId: updateCustomerGroup
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -1106,7 +1106,7 @@ paths:
 
         **Notes**
         All existing customers are unassigned from the group when it is deleted.
-      operationId: deleteACustomerGroup
+      operationId: deleteCustomerGroup
       responses:
         '204':
           description: No content. Request was successful but produced no response.
@@ -1126,7 +1126,7 @@ paths:
         - Customer Groups
       summary: Get a Count of Customer Groups
       description: Returns a count of all *Customer Groups*.
-      operationId: getACountOfCustomerGroups
+      operationId: getCustomerGroupsCount
       responses:
         '200':
           description: ''

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -46,7 +46,7 @@ paths:
       summary: Get All Customers
       tags:
         - Customers
-      operationId: CustomersGet
+      operationId: getCustomers
       deprecated: false
       parameters:
         - name: page
@@ -228,7 +228,7 @@ paths:
       summary: Create Customers
       tags:
         - Customers
-      operationId: CustomersPost
+      operationId: createCustomers
       deprecated: false
       requestBody:
         content:
@@ -318,7 +318,7 @@ paths:
       summary: Update Customers
       tags:
         - Customers
-      operationId: CustomersPut
+      operationId: updateCustomers
       deprecated: false
       responses:
         '200':
@@ -383,7 +383,7 @@ paths:
       summary: Delete Customers
       tags:
         - Customers
-      operationId: CustomersDelete
+      operationId: deleteCustomers
       deprecated: false
       parameters:
         - in: query
@@ -406,7 +406,7 @@ paths:
     get:
       description: Returns a list of Customer Addresses. Optional filter parameters can be passed in.
       summary: Get All Customer Addresses
-      operationId: CustomersAddressesGet
+      operationId: getCustomersAddresses
       deprecated: false
       parameters:
         - name: Accept
@@ -510,7 +510,7 @@ paths:
           * **postal_code**
         * An attempt to create an address that already exists will result in no change to the address or custom form field values, an HTTP 200 return code, and the address will be absent from the response body.
       summary: Create a Customer Address
-      operationId: CustomersAddressesPost
+      operationId: createCustomersAddresses
       deprecated: false
       parameters:
         - name: Accept
@@ -601,7 +601,7 @@ paths:
           * **postal_code**
         * An attempt to update an address such that it becomes identical to another address that already exists will result in no change to the target address or custom form field values. The response will have an HTTP 200 return code, and the address will be absent from the response body.
       summary: Update a Customer Address
-      operationId: CustomersAddressesPut
+      operationId: updateCustomersAddresses
       deprecated: false
       parameters:
         - name: Accept
@@ -677,7 +677,7 @@ paths:
         **Required Query**
         * id:in -- ID of the *Customer Address*
       summary: Delete a Customer Address
-      operationId: CustomersAddressesDelete
+      operationId: deleteCustomersAddresses
       deprecated: false
       parameters:
         - name: Accept
@@ -714,7 +714,7 @@ paths:
         - Customer Validate Credentials
       description: Validate a customer credentials - This endpoint has special rate limiting protections to protect against abuse.
       summary: Validate a customer credentials
-      operationId: CustomerValidateCredentials
+      operationId: validateCustomerCredentials
       requestBody:
         required: true
         content:
@@ -765,7 +765,7 @@ paths:
         - Customer Settings
       description: Returns the global-level customer settings.
       summary: Get Customer Settings
-      operationId: CustomerSettingsGet
+      operationId: getCustomersSettings
       responses:
         '200':
           description: Returns customer settings values for global level.
@@ -787,7 +787,7 @@ paths:
         - Customer Settings
       description: Updates the customer settings on the global level.
       summary: Update Customer Settings
-      operationId: CustomerSettingsPut
+      operationId: updateCustomersSettings
       requestBody:
         content:
           application/json:
@@ -831,7 +831,7 @@ paths:
 
          * `null` indicates that there is no override per given channel and values are inherited from the global level.
       summary: Get Customer Settings per Channel
-      operationId: CustomerSettingsChannelGet
+      operationId: getCustomersSettingsChannel
       parameters:
         - in: path
           name: channel_id
@@ -868,7 +868,7 @@ paths:
 
         * Setting `null` will delete override per given channel, and values will be inherited from the global level. Make sure the channel has `allow_global_logins` enabled.
       summary: Update Customer Settings per Channel
-      operationId: CustomerSettingsChannelPut
+      operationId: updateCustomersSettingsChannel
       parameters:
         - in: path
           name: channel_id
@@ -919,7 +919,7 @@ paths:
     get:
       description: Returns a list of Customer Attributes. You can pass in optional filter parameters.
       summary: Get All Customer Attributes
-      operationId: CustomersAttributesGet
+      operationId: getCustomersAttributes
       deprecated: false
       parameters:
         - name: page
@@ -1026,7 +1026,7 @@ paths:
 
         A store cannot have more than 50 customer attributes.
       summary: Create a Customer Attribute
-      operationId: CustomersAttributesPost
+      operationId: createCustomersAttributes
       deprecated: false
       parameters:
         - name: Accept
@@ -1075,7 +1075,7 @@ paths:
         **Limits**
         * Limit of 3 concurrent requests.
       summary: Update a Customer Attribute
-      operationId: CustomersAttributesPut
+      operationId: updateCustomersAttributes
       deprecated: false
       parameters:
         - name: Accept
@@ -1119,7 +1119,7 @@ paths:
         **Required Query**
         * id:in -- ID of the *Customer Attribute*
       summary: Delete Customer Attributes
-      operationId: CustomersAttributesDelete
+      operationId: deleteCustomersAttributes
       deprecated: false
       parameters:
         - name: 'id:in'
@@ -1153,7 +1153,7 @@ paths:
     get:
       description: Returns a list of Customer Attribute Values. Optional filter parameters can be passed in.
       summary: Get All Customer Attribute Values
-      operationId: CustomersAttributeValuesGet
+      operationId: getCustomersAttributeValues
       deprecated: false
       parameters:
         - name: Accept
@@ -1247,7 +1247,7 @@ paths:
         **Limits**
         * 10 per call limit.
       summary: Upsert Customer Attribute Values
-      operationId: CustomersAttributeValuesPut
+      operationId: upsertCustomersAttributeValues
       deprecated: false
       parameters:
         - name: Accept
@@ -1312,7 +1312,7 @@ paths:
         **Required Query**
         * id:in - ID of the *Customer Attribute Value*
       summary: Delete Customer Attribute Values
-      operationId: CustomersAttributeValuesDelete
+      operationId: delteCustomersAttributeValues
       deprecated: false
       parameters:
         - name: 'id:in'
@@ -1360,7 +1360,7 @@ paths:
         Returns a list of form field values for the Customer or Customer Address object.
 
         To learn about adding and managing form fields, see [Adding and Editing Fields in the Account Signup Form](https://support.bigcommerce.com/s/article/Editing-Form-Fields).
-      operationId: CustomerFormFieldsGet
+      operationId: getCustomersFormFieldValues
       tags:
         - Customer Form Field Values
       parameters:
@@ -1442,7 +1442,7 @@ paths:
 
         **Limits**
         * Limit of 10 concurrent requests.
-      operationId: CustomerFormFieldValuePUT
+      operationId: updateCustomerFormFieldValues
       tags:
         - Customer Form Field Values
       requestBody:
@@ -1470,7 +1470,7 @@ paths:
       summary: Get Customer Consent
       tags:
         - Customer Consent
-      operationId: CustomersConsentByCustomerId_GET
+      operationId: getCustomerConsent
       deprecated: false
       responses:
         '200':
@@ -1498,7 +1498,7 @@ paths:
       summary: Update Customer Consent
       tags:
         - Customer Consent
-      operationId: CustomersConsentByCustomerId_PUT
+      operationId: updateCustomerConsent
       deprecated: false
       parameters:
         - name: Content-Type
@@ -1549,7 +1549,7 @@ paths:
       description: |-
         Lists all available stored instruments for a customer. This list will include all types of stored instruments namely card, account and bank_account instruments
 
-      operationId: liststoredinstruments
+      operationId: getCustomerStoredInstruments
       parameters:
         - $ref: '#/components/parameters/customerId'
       responses:

--- a/reference/geography.v2.yml
+++ b/reference/geography.v2.yml
@@ -10,6 +10,7 @@ paths:
     get:
       description: 'Get a list of all countries available. A country or territory, identifiable by an ISO 3166 country code.'
       summary: Get All Countries
+      operationId: getCountries
       parameters:
         - name: Accept
           in: header
@@ -62,6 +63,7 @@ paths:
     get:
       description: 'Returns a single *Country*.  Gets a country. A country or territory, identifiable by an ISO 3166 country code.'
       summary: Get a Country
+      operationId: getCountry
       parameters:
         - name: id
           in: path
@@ -103,6 +105,7 @@ paths:
         Returns a list of *States* belonging to a *Country*. 
         A state or province, identifiable by an ISO 3166 subdivision code.
       summary: Get All Country's States
+      operationId: getCountryStates
       parameters:
         - name: country_id
           in: path
@@ -166,6 +169,7 @@ paths:
 
   '/countries/{country_id}/states/{id}':
     get:
+      operationId: getCountryState
       description: |-
         Returns a *State*. 
         A state or province, identifiable by an ISO 3166 subdivision code.
@@ -232,10 +236,11 @@ paths:
       summary: Get a Count of All Countries
       tags:
         - Countries
-      operationId: countriesCount
+      operationId: getCountriesCount
       description: Returns a count of all countries.
   '/countries/states/count':
     get:
+      operationId: getStatesCount
       responses:
         '200':
           $ref: '#/components/responses/countResponse'
@@ -252,6 +257,7 @@ paths:
       tags:
         - States
       description: Returns a list of all states.
+      operationId: getStates
       parameters:
         - schema:
             type: integer
@@ -265,6 +271,7 @@ paths:
           description: The ordered grouping of results to return.
   '/countries/{country_id}/states/count':
     get:
+      operationId: getCountryStatesCount
       responses:
         '200':
           $ref: '#/components/responses/countResponse'

--- a/reference/global_refs.yaml
+++ b/reference/global_refs.yaml
@@ -39,11 +39,11 @@ paths:
                     signUpDate: '2019-08-24'
         '404':
           description: User Not Found
-      operationId: get-users-userId
+      operationId: getUser
       description: Retrieve the information of the user with the matching user ID.
     patch:
       summary: Update User Information
-      operationId: patch-users-userId
+      operationId: updateUser
       tags:
         - Experiment
       responses:
@@ -98,7 +98,7 @@ paths:
   '/user':
     post:
       summary: Create New User
-      operationId: post-user
+      operationId: createUser
       tags:
         - Experiment
       responses:

--- a/reference/marketing.v2.yml
+++ b/reference/marketing.v2.yml
@@ -68,7 +68,7 @@ paths:
         shipping_methods : null
         ...
         ```
-      operationId: getAllCoupons
+      operationId: getCoupons
       parameters:
       - name: id
         in: query
@@ -191,7 +191,7 @@ paths:
       tags:
       - Coupons
       summary: Create a New Coupon
-      operationId: createANewCoupon
+      operationId: createCoupon
       description: |-
         Creates a *Coupon*.
 
@@ -259,7 +259,7 @@ paths:
       description: |
         ## Usage Notes
         * Deleting a coupon via this endpoint will delete the coupon but not the promotion it is attached to
-      operationId: deleteAllCoupons
+      operationId: deleteCoupons
       parameters:
       - name: id:in
         in: query
@@ -279,7 +279,7 @@ paths:
       - Coupons
       summary: Get a Count of Coupons
       description: Returns a count of all *Coupons* in the store.
-      operationId: getACountOfCoupons
+      operationId: getCouponsCount
       responses:
         '200':
           description: ""
@@ -321,7 +321,7 @@ paths:
         **Notes**
 
         If the `applies_to` value is cleared, you can restore it to the coupon by reapplying the `applies_to` value in a new `PUT` request.
-      operationId: updateACoupon
+      operationId: updateCoupon
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -362,7 +362,7 @@ paths:
       - Coupons
       summary: Delete a Coupon
       description: Deletes a *Coupon*.
-      operationId: deleteACoupon
+      operationId: deleteCoupon
       responses:
         '204':
           description: ""
@@ -376,7 +376,7 @@ paths:
       summary: Get All Banners
       description: Returns a list of *Banners*. Default sorting is by banner id, from
         lowest to highest.
-      operationId: getAllBanners
+      operationId: getBanners
       parameters:
       - name: min_id
         in: query
@@ -455,7 +455,7 @@ paths:
         **Read Only Fields**
         * date_created
         * id
-      operationId: createABanner
+      operationId: createBanner
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -489,7 +489,7 @@ paths:
       - Banners
       summary: Delete All Banners
       description: By default, it deletes all *Banners*.
-      operationId: deleteAllBanners
+      operationId: deleteBanners
       responses:
         '204':
           description: ""
@@ -510,7 +510,7 @@ paths:
       - Banners
       summary: Get a Banner
       description: Returns a single *Banner*
-      operationId: getABanner
+      operationId: getBanner
       responses:
         '200':
           description: ""
@@ -540,7 +540,7 @@ paths:
         **Read Only Fields**
         * date_created
         * id
-      operationId: updateABanner
+      operationId: updateBanner
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -574,7 +574,7 @@ paths:
       - Banners
       summary: Delete a Banner
       description: Deletes a *Banner*.
-      operationId: deleteABanner
+      operationId: deleteBanner
       responses:
         '204':
           description: ""
@@ -587,7 +587,7 @@ paths:
       - Banners
       summary: Get a Count of Store Banners
       description: Returns a count of *Banners*.
-      operationId: getACountOfBanners
+      operationId: getBannersCount
       responses:
         '200':
           description: ""
@@ -617,7 +617,7 @@ paths:
       - Gift Certificates
       summary: Get a Gift Certificate
       description: Returns a single *Gift Certificate*.
-      operationId: getAGiftCertificate
+      operationId: getGiftCertificate
       responses:
         '200':
           description: ""
@@ -651,7 +651,7 @@ paths:
         **Read Only Fields**
         * id
         * order_id
-      operationId: updateAGiftCertificate
+      operationId: updateGiftCertificate
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -689,7 +689,7 @@ paths:
       - Gift Certificates
       summary: Delete a Gift Certificate
       description: Deletes a *Gift Certificate*.
-      operationId: deleteAGiftCertificate
+      operationId: deleteGiftCertificate
       responses:
         '204':
           description: ""
@@ -707,7 +707,7 @@ paths:
         Default sorting is by gift-certificate id, from lowest to highest.
 
         The maximum limit is 250. If a limit isn’t provided, up to 50 gift_certificates are returned by default.
-      operationId: getAllGiftCertificates
+      operationId: getGiftCertificates
       parameters:
       - name: min_id
         in: query
@@ -829,7 +829,7 @@ paths:
         **Notes**
 
         When a gift certificate is created through the API, no email notification is triggered to the specified recipient.
-      operationId: createAGiftCertificate
+      operationId: createGiftCertificate
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -868,7 +868,7 @@ paths:
       - Gift Certificates
       summary: Delete All Gift Certificates
       description: By default, it deletes all *Gift Certificates*.
-      operationId: deleteAllGiftCertificates
+      operationId: deleteGiftCertificates
       responses:
         '204':
           description: ""

--- a/reference/orders.sf.yml
+++ b/reference/orders.sf.yml
@@ -33,7 +33,7 @@ paths:
         > #### Note
         > * Substitute your storefront domain for `yourstore.example.com`. 
         > * The Send a Test Request feature is not currently supported for this endpoint.
-      operationId: OrdersByOrderIdGet
+      operationId: getOrder
       parameters:
         - name: orderId
           in: path

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -2114,7 +2114,7 @@ components:
                     display_value: BigCommerceLogo.jpeg
                     display_value_customer: BigCommerceLogo.jpeg
                     display_value_merchant: BigCommerceLogo.jpeg
-                    value: {\"originalName\":\"BigCommerceLogo.jpeg\",\"temporaryPath\":\"121_fbfb71dfc5a5d911f62d8e35dedd6e45.jpeg\",\"path\":\"f606efcae7e179970b19c3658142c5d0.jpeg\"}
+                    value: "{\"originalName\":\"BigCommerceLogo.jpeg\",\"temporaryPath\":\"121_fbfb71dfc5a5d911f62d8e35dedd6e45.jpeg\",\"path\":\"f606efcae7e179970b19c3658142c5d0.jpeg\"}"
                     type: File upload field
                     name: Custom Logo Engraving
                     display_style: ""

--- a/reference/orders.v2.oas2.yml
+++ b/reference/orders.v2.oas2.yml
@@ -86,7 +86,7 @@ paths:
           content:
             application/json:
               schema: {}
-      operationId: getAnOrder
+      operationId: getOrder
     put:
       description: |-
         Updates an *Order*. 
@@ -183,7 +183,7 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/order_Resp'
-      operationId: updateAnOrder
+      operationId: updateOrder
     delete:
       description: Archives an order. To remove a single product from an order, see `PUT /orders/{order_id}`.
       summary: Archive an Order
@@ -192,7 +192,7 @@ paths:
       responses:
         '204':
           description: ''
-      operationId: deleteAnOrder
+      operationId: deleteOrder
   '/orders/count':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -204,7 +204,7 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/ordersCount_Resp'
-      operationId: getCountOrder
+      operationId: getOrdersCount
   '/orders':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -243,7 +243,7 @@ paths:
         '200':
           $ref: '#/components/responses/orderCollection_Resp'
       summary: Get All Orders
-      operationId: getAllOrders
+      operationId: getOrders
     post:
       description: |-
         Creates an *Order*. To learn more about creating or updating orders, see [Orders Overview](/api-docs/orders/orders-api-overview).
@@ -427,7 +427,7 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/order_Resp'
-      operationId: createAnOrder
+      operationId: createOrder
     delete:
       description: Archives all orders.
       summary: Delete All Orders
@@ -438,7 +438,7 @@ paths:
       responses:
         '204':
           description: ''
-      operationId: deleteAllOrders
+      operationId: deleteOrders
   '/orders/{order_id}/coupons':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -464,7 +464,7 @@ paths:
           $ref: '#/components/responses/orderCouponsCollection_Resp'
       tags:
         - Order Coupons
-      operationId: getAllOrderCoupons
+      operationId: getOrderCoupons
   '/orders/{order_id}/products':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -481,7 +481,7 @@ paths:
           $ref: '#/components/responses/orderProductsCollection_Resp'
       tags:
         - Order Products
-      operationId: getAllOrderProducts
+      operationId: getOrderProducts
   '/orders/{order_id}/shipping_addresses':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -500,7 +500,7 @@ paths:
           $ref: '#/components/responses/orderShippingAddressCollection_Resp'
       tags:
         - Order Shipping Addresses
-      operationId: getAllShippingAddresses
+      operationId: getOrderShippingAddresses
   '/order_statuses':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -532,7 +532,7 @@ paths:
           $ref: '#/components/responses/orderStatusCollection_Resp'
       tags:
         - Order Status
-      operationId: getOrderStatus
+      operationId: getOrderStatuses
   '/order_statuses/{status_id}':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -565,7 +565,7 @@ paths:
           $ref: '#/components/responses/orderStatus_Resp'
       tags:
         - Order Status
-      operationId: getAOrderStatus
+      operationId: getOrderStatusesStatus
   '/orders/{order_id}/taxes':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -609,7 +609,7 @@ paths:
           $ref: '#/components/responses/orderShipmentCollection_Resp'
       tags:
         - Order Shipments
-      operationId: getAllOrderShipments
+      operationId: getOrderShipments
     post:
       description: |
         Creates an *Order Shipment*. For more details, see [Shipping an Order](/api-docs/orders/orders-api-overview#creating-order-shipments).
@@ -655,7 +655,7 @@ paths:
           description: ''
       tags:
         - Order Shipments
-      operationId: deleteAllOrderShipments
+      operationId: deleteOrderShipments
   '/orders/{order_id}/shipments/count':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -668,7 +668,7 @@ paths:
           $ref: '#/components/responses/orderCount_Resp'
       tags:
         - Order Shipments
-      operationId: getCountShipments
+      operationId: getOrderShipmentsCount
   '/orders/{order_id}/shipments/{shipment_id}':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -754,7 +754,7 @@ paths:
       description: Gets a product line item associated with the order.
       tags:
         - Order Products
-      operationId: getAnOrderProduct
+      operationId: getOrderProduct
   '/orders/{order_id}/shipping_addresses/{id}':
     parameters:
       - $ref: '#/components/parameters/Accept'
@@ -776,10 +776,10 @@ paths:
         Returned in the response is shipping_quotes object. Please use the Get Shipping Quotes Endpoint. Using the response will return a 204 for the shipping quote.
       tags:
         - Order Shipping Addresses
-      operationId: getAShippingAddress
+      operationId: getOrderShippingAddress
     put:
       summary: Update a Shipping Address
-      operationId: updateAShippingAddress
+      operationId: updateOrderShippingAddress
       responses:
         '200':
           description: OK
@@ -903,7 +903,7 @@ paths:
         This is a read-only endpoint and the output can vary based on the shipping quote. A shipping quote can only be generated using the storefront at this time. Orders that are created in the control panel or using the API return a 204 for this endpoint since a shipping quote is not generated during that process.
       tags:
         - Order Shipping Addresses Quotes
-      operationId: getShippingQuotes
+      operationId: getOrderShippingAddressShippingQuotes
   '/orders/{order_id}/consignments':
     parameters:
       - schema:
@@ -956,7 +956,7 @@ paths:
                             resource: /orders/129/products/12
         '404':
           $ref: '#/components/responses/404_Resp'
-      operationId: get-orders-orderId-consignments
+      operationId: getOrderConsignments
       description: 'Get all consignments for an order. '
       parameters:
         - $ref: '#/components/parameters/order_id_path'
@@ -1015,7 +1015,7 @@ paths:
                     method_id: 5
         '404':
           $ref: '#/components/responses/404_Resp'
-      operationId: get-orders-orderId-consignments-shipping-shippingId-shippingQuotes
+      operationId: getOrderConsignmentShippingQuotes
       description: |-
         Get all shipping quotes persisted on an order for a shipping consignment.
         This is a read-only endpoint whose response depends on the shipping quote. You can only generate a shipping quote using the storefront at this time. Orders that are created in the control panel, or using the API, return a 204 status response since you can't generate a shipping quote during that process.

--- a/reference/orders.v3.yml
+++ b/reference/orders.v3.yml
@@ -33,7 +33,7 @@ paths:
         Requires at least one of the following scopes:
         * `store_v2_orders`
         * `store_v2_transactions`
-      operationId: paymentactioncapture
+      operationId: captureOrderPayment
       parameters:
         - $ref: '#/components/parameters/ContentType'
       responses:
@@ -65,7 +65,7 @@ paths:
         Requires at least one of the following scopes:
         * `store_v2_orders`
         * `store_v2_transactions`
-      operationId: paymentactionvoid
+      operationId: voidOrderPayment
       parameters:
         - $ref: '#/components/parameters/ContentType'
       responses:
@@ -105,7 +105,7 @@ paths:
         Requires at least one of the following scopes:
         * `store_v2_transactions_read_only`
         * `store_v2_transactions`
-      operationId: getTransactions
+      operationId: getOrderTransactions
       responses:
         '200':
           $ref: '#/components/responses/TransactionCollection_Resp'
@@ -165,7 +165,7 @@ paths:
         **Note:**
         Order refunds are processed consecutively. Processing synchronous refunds on an order are not yet supported.
 
-      operationId: postrefundquote
+      operationId: createOrderRefundQuotes
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -231,7 +231,7 @@ paths:
         **Note:**
         Order refunds are processed consecutively. Processing synchronous refunds on an order are not yet supported.
         
-      operationId: postrefund
+      operationId: createOrderRefund
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -350,7 +350,7 @@ paths:
         * `store_v2_transactions`
         * `store_v2_orders_read_only`
         * `store_v2_orders`
-      operationId: getorderrefunds
+      operationId: getOrderRefunds
       responses:
         '200':
           $ref: '#/components/responses/RefundCollection_Resp'
@@ -371,7 +371,7 @@ paths:
     get:
       summary: Get a Refund
       description: Returns a refund by refund ID.
-      operationId: RefundID_Get
+      operationId: getOrderRefund
       responses:
         '200':
           $ref: '#/components/responses/RefundID_Response'
@@ -390,7 +390,7 @@ paths:
         * `store_v2_transactions`
         * `store_v2_orders_read_only`
         * `store_v2_orders`
-      operationId: getrefunds
+      operationId: getOrdersRefunds
       tags:
         - Payment Actions
       parameters:
@@ -459,7 +459,7 @@ paths:
         Requires at least one of the following scopes:
         * `store_v2_orders`
         * `store_v2_transactions`
-      operationId: postrefundquotes
+      operationId: createOrdersRefundQuotes
       parameters:
         - $ref: '#/components/parameters/Accept'
       requestBody:
@@ -573,7 +573,7 @@ paths:
         Gets a `Metafield` object list, by `order_id`.
 
         The maximum number of metafields allowed on each order, product, category, variant, or brand is 250 per client ID.
-      operationId: getOrderMetafieldsByOrderId
+      operationId: getOrderMetafields
       parameters:
         - $ref: '#/components/parameters/PageParam'
         - $ref: '#/components/parameters/LimitParam'
@@ -661,7 +661,7 @@ paths:
         - Metafields
       description: |
         Gets a `Metafield`, by `order_id`.
-      operationId: getOrderMetafieldByOrderIdAndMetafieldId
+      operationId: getOrderMetafield
       responses:
         '200':
           description: |
@@ -717,7 +717,7 @@ paths:
         - Metafields
       description: |
         Deletes a `Metafield`.
-      operationId: deleteOrderMetafieldById
+      operationId: deleteOrderMetafield
       responses:
         '204':
           description: |
@@ -726,7 +726,7 @@ paths:
     get:
       summary: Get Global Order Settings
       description: Returns global order settings.
-      operationId: GetGlobalOrderSettings
+      operationId: getGlobalOrderSettings
       tags:
         - Order Settings
       responses:
@@ -751,7 +751,7 @@ paths:
     put:
       summary: Update Global Order Settings
       description: Updates global order settings.
-      operationId: UpdateGlobalOrderSettings
+      operationId: updateGlobalOrderSettings
       parameters:
         - $ref: '#/components/parameters/ContentType'
       tags:
@@ -796,7 +796,7 @@ paths:
     get:
       summary: Get Channel Order Settings
       description: Returns order settings for a specific channel.
-      operationId: GetChannelOrderSettings
+      operationId: getChannelOrderSettings
       tags:
         - Order Settings
       responses:
@@ -824,7 +824,7 @@ paths:
         Updates order settings for a specific channel.
 
          **Note:** You must override both notifications `email_addresses` or neither, i.e. either both notification `email_addresses` are an array of valid email addresses, or both `email_addresses` must be null. You may not have one set to an array of addresses and the other set to `null`.
-      operationId: UpdateChannelOrderSettings
+      operationId: updateChannelOrderSettings
       parameters:
         - $ref: '#/components/parameters/ContentType'
       tags:

--- a/reference/pages.v3.yml
+++ b/reference/pages.v3.yml
@@ -44,7 +44,7 @@ security:
 paths:
   '/content/pages':
     get:
-      operationId: content-pages-get
+      operationId: getPages
       tags:
         - Pages (Bulk)
       description: Returns one or more content pages. This endpoint supports bulk operations.
@@ -77,7 +77,7 @@ paths:
         - $ref: '#/components/parameters/includeQuery'
       summary: Get Pages
     post:
-      operationId: content-pages-post
+      operationId: updatePages
       tags:
         - Pages (Bulk)
       description: Creates one or more content pages. This endpoint supports bulk operations.
@@ -123,7 +123,7 @@ paths:
         - $ref: '#/components/parameters/ContentType'
       summary: Create Pages
     put:
-      operationId: content-pages-put
+      operationId: updatePages
       tags:
         - Pages (Bulk)
       description: Updates one or more content pages. This endpoint supports bulk operations.
@@ -207,7 +207,7 @@ paths:
         - $ref: '#/components/parameters/ContentType'
       summary: Update Pages
     delete:
-      operationId: content-pages-delete
+      operationId: deletePages
       tags:
         - Pages (Bulk)
       description: |-
@@ -251,7 +251,7 @@ paths:
       - $ref: '#/components/parameters/Accept'
   '/content/pages/{pageId}':
     get:
-      operationId: content-page-get
+      operationId: getPage
       tags:
         - Pages (Single)
       description: |-
@@ -436,7 +436,7 @@ paths:
         - $ref: '#/components/parameters/includeQuery'
       summary: Get a Page
     put:
-      operationId: content-page-put
+      operationId: updatePage
       tags:
         - Pages (Single)
       description: Updates one content page.
@@ -484,7 +484,7 @@ paths:
         - $ref: '#/components/parameters/includeQuery'
       summary: Update a Page
     delete:
-      operationId: content-page-delete
+      operationId: deletePage
       tags:
         - Pages (Single)
       description: |-

--- a/reference/payments/accepted-methods_payments.v3.yml
+++ b/reference/payments/accepted-methods_payments.v3.yml
@@ -67,7 +67,7 @@ paths:
       summary: Get Accepted Payment Methods
       tags:
         - Methods 
-      operationId: PaymentsMethodsGet
+      operationId: getPaymentMethods
       deprecated: false
       parameters:
         - name: order_id

--- a/reference/payments/access-tokens_payments.v3.yml
+++ b/reference/payments/access-tokens_payments.v3.yml
@@ -66,7 +66,7 @@ paths:
       summary: Create Payment Access Token
       tags:
         - Tokens
-      operationId: PaymentsAccessTokensPost
+      operationId: createPaymentAccessToken
       deprecated: false
       parameters:
         - $ref: '#/components/parameters/ContentType'

--- a/reference/price_lists.v3.yml
+++ b/reference/price_lists.v3.yml
@@ -78,7 +78,7 @@ paths:
         - Price Lists
       summary: Get All Price Lists
       description: Returns a list of *Price Lists*. Optional parameters can be passed in.
-      operationId: getPriceListCollection
+      operationId: getPriceLists
       parameters:
         - name: id
           in: query
@@ -435,7 +435,7 @@ paths:
         - Price Lists
       summary: Delete All Price Lists
       description: Deletes a *Price List*. All associated price records are also removed. Optional parameters can be passed in.
-      operationId: deletePriceListsByFilter
+      operationId: deletePriceLists
       parameters:
         - name: id
           in: query
@@ -772,7 +772,7 @@ paths:
         - Price Lists Records
       summary: Create Batch of Price Lists Records
       description: Creates a batch of `Price Lists Records`; may include price list records from more than one price list.  Concurrency limit of 1.
-      operationId: UpsertPriceListRecords
+      operationId: upsertPriceListRecords
       requestBody: 
         content: 
           application/json:
@@ -808,7 +808,7 @@ paths:
         **Notes**
         * Supports up to 10 simultaneous GET requests. Running more than the allowed number of requests concurrently on the same store will result in a `429` status error and your additional requests will fail.
         * Store Pricelist Records data to reduce the number of calls and maximize performance.
-      operationId: getPriceListRecordCollection
+      operationId: getPriceListRecords
       parameters:
         - name: price_list_id
           in: path
@@ -1428,7 +1428,7 @@ paths:
         * Batch requests support up to 1,000 items per request.
         * Up to 2 concurrent batch upsert requests are supported with this API. Running more than the allowed concurrent requests in parallel on the **same store** will cause a `429` error, and your additional requests will fail. You are encouraged to run requests sequentially with as many records per request as possible to maximize performance.
         * When updating a product with variants, or multiple SKUs, don't include records for the parent product SKU.
-      operationId: setPriceListRecordCollection
+      operationId: upsertPriceListRecords
       parameters:
         - name: price_list_id
           in: path
@@ -1626,7 +1626,7 @@ paths:
         - Price Lists Records
       summary: Delete a Price List Record
       description: Deletes a *Price List Record*. Deleting the records does not delete the Price List. Optional parameters can be passed in.
-      operationId: deletePriceListRecordsByFilter
+      operationId: deletePriceListRecords
       parameters:
         - name: price_list_id
           in: path
@@ -2495,7 +2495,7 @@ paths:
         - Price Lists Assignments
       summary: Get Price List Assignments
       description: Fetches an array of `Price List Assignments` matching a particular Customer Group and Price List and Channel.
-      operationId: GetListOfPriceListAssignments
+      operationId: getListOfPriceListAssignments
       parameters:
         - name: id
           in: query
@@ -2577,7 +2577,7 @@ paths:
         Creates a batch of `Price List Assignments`. 
         **Note:** The batch limit for `Price List Assignments` is 25.
       summary: Create Price List Assignments
-      operationId: CreatePriceListAssignments
+      operationId: createPriceListAssignments
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -2604,7 +2604,7 @@ paths:
         - Price Lists Assignments
       summary: Delete Price List Assignments
       description: 'Deletes one or more `Price List Assignments` objects from BigCommerce using a query parameter. You must use at least one query parameter. '
-      operationId: deletePriceListAssignmentsByFilter
+      operationId: deletePriceListAssignments
       parameters:
         - $ref: '#/components/parameters/FilterAssignmentIdParam'
         - $ref: '#/components/parameters/FilterPriceListIdParam'

--- a/reference/pricing.sf.yml
+++ b/reference/pricing.sf.yml
@@ -31,7 +31,7 @@ paths:
 
         **Limits**
         * Limit of 50 concurrent requests.
-      operationId: get-prices
+      operationId: getPrices
       requestBody:
         content:
           application/json:

--- a/reference/redirects.v3.yml
+++ b/reference/redirects.v3.yml
@@ -29,7 +29,7 @@ paths:
         - Redirects
       summary: Get Redirects
       description: Returns a collection of the store's 301 redirects across all sites.
-      operationId: GetRedirects
+      operationId: getRedirects
       parameters:
         - name: site_id
           in: query
@@ -104,7 +104,7 @@ paths:
         - Redirects
       summary: Upsert Redirects
       description: Upserts new redirect data across all storefronts.
-      operationId: UpsertRedirects
+      operationId: upsertRedirects
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -134,7 +134,7 @@ paths:
         - Redirects
       summary: Delete Redirects
       description: Deletes redirects.
-      operationId: DeleteRedirects
+      operationId: deleteRedirects
       parameters:
         - name: 'id:in'
           in: query

--- a/reference/settings.v3.yml
+++ b/reference/settings.v3.yml
@@ -230,7 +230,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
     get:
-      operationId: get-settings-emails-enabled
+      operationId: getSettingsEmailStatuses
       summary: Get Transactional Email Settings
       description: Get global transactional email settings or channel specific overrides by `channel_id`.
       parameters:
@@ -266,7 +266,7 @@ paths:
       tags:
         - Email Statuses
     put:
-      operationId: put-settings-transactional-emails-enabled
+      operationId: updateSettingsEmailStatuses
       summary: Update Transactional Email Settings
       description: Update global transactional email settings or create channel specific overrides by `channel_id`.
       parameters:
@@ -325,7 +325,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
     post:
-      operationId: post-favicon-logo-image
+      operationId: createSettingsFaviconImage
       summary: Create Favicon Image
       description: |-
         Uploads an image file to use as the storefront favicon. Supported MIME types include GIF, JPEG, and PNG. 
@@ -398,7 +398,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
     get:
-      operationId: get-settings-logo
+      operationId: getSettingsLogo
       summary: Get Store Logo Settings
       description: |-
         Returns store logo settings.
@@ -423,7 +423,7 @@ paths:
       tags:
         - Logo
     put:
-      operationId: put-settings-logo
+      operationId: updateSettingsLogo
       summary: Update Store Logo Settings
       description: |-
         Updates the logo type and logo text for a textual logo. To upload new images, use the dedicated image POST endpoints.
@@ -456,7 +456,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
     post:
-      operationId: post-settings-logo-image
+      operationId: createSettingsLogoImage
       summary: Create Logo Image
       description: |-
         Uploads an image file to use as the storefront logo. Supported MIME types include GIF, JPEG, and PNG. 
@@ -481,7 +481,7 @@ paths:
         - Logo Image
   '/settings/search/filters':
     get:
-      operationId: getEnabled
+      operationId: getSettingsEnabledSearchFilters
       summary: Get Enabled Filters
       description: 'Returns a list of enabled default [Product Filtering](https://support.bigcommerce.com/s/article/Product-Filtering-Settings) filters. These filters will be used if a store does not have contextual overrides.'
       responses:
@@ -537,7 +537,7 @@ paths:
       tags:
         - Search Filters
     put:
-      operationId: updateEnabled
+      operationId: updateSettingsEnabledSearchFilters
       summary: Update Enabled Filters
       description: 'Updates enabled default [Product Filtering](https://support.bigcommerce.com/s/article/Product-Filtering-Settings) filters.'
       parameters:
@@ -639,7 +639,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
     get:
-      operationId: getAvailable
+      operationId: getSettingsAvailableFilters
       summary: Get Available Filters
       description: 'Returns a list of filters available to power [Product Filtering](https://support.bigcommerce.com/s/article/Product-Filtering-Settings).'
       parameters:
@@ -707,7 +707,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
     get:
-      operationId: getContexts
+      operationId: getSettingsFiltersContexts
       summary: Get Contextual Filters
       description: |-
         Returns a list of contextual filters enabled for a particular channel or category.
@@ -745,7 +745,7 @@ paths:
       tags:
         - Search Filters
     put:
-      operationId: upsertContexts
+      operationId: upsertSettingsFiltersContexts
       summary: Upsert Contextual Filters
       description: |-
         Upserts contextual filters for a particular channel or category.
@@ -978,7 +978,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
     get:
-      operationId: get-settings-storefront-product
+      operationId: getSettingsStorefrontProduct
       summary: Get Storefront Product Settings
       description: |-
         Returns product settings.
@@ -994,7 +994,7 @@ paths:
       tags:
         - Storefront Product
     put:
-      operationId: put-settings-storefront-product
+      operationId: updateSettingsStorefrontProduct
       summary: Update Storefront Product Settings
       description: |-
         Updates product settings.
@@ -1084,7 +1084,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/Accept'
     get:
-      operationId: ''
+      operationId: getSettingsStorefrontSearch
       summary: Get Storefront Search Settings
       description: |-
         Returns search settings.

--- a/reference/shipping.v2.yml
+++ b/reference/shipping.v2.yml
@@ -186,7 +186,7 @@ paths:
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-      operationId: getAllShippingZones
+      operationId: getShippingZones
     post:
       description: Creates a *Shipping Zone*.
       summary: Create a Shipping Zone
@@ -389,7 +389,7 @@ paths:
                     example: true
                     type: boolean
               examples: {}
-      operationId: createAShippingZones
+      operationId: createShippingZones
   '/shipping/zones/{id}':
     get:
       description: Returns a single *Shipping Zone*.
@@ -482,7 +482,7 @@ paths:
                     description: Whether this shipping zone is enabled.
                     example: true
                     type: boolean
-      operationId: getAShippingZone
+      operationId: getShippingZone
     put:
       description: |-
         Updates a *Shipping Zone*.
@@ -674,7 +674,7 @@ paths:
                     type: boolean
                 required:
                   - name
-      operationId: updateAShippingZone
+      operationId: updateShippingZone
     delete:
       description: Deletes a *Shipping Zone*.
       summary: Delete a Shipping Zone
@@ -689,7 +689,7 @@ paths:
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-      operationId: deleteAShippingZone
+      operationId: deleteShippingZone
     parameters:
       - $ref: '#/components/parameters/Accept'
       - name: id
@@ -797,7 +797,7 @@ paths:
                       handling_fees:
                         percentage_surcharge: "0"
                       is_fallback: false
-      operationId: getShippingMethodsZone
+      operationId: getShippingZoneMethods
     post:
       description: |-
         Creates a *Shipping Method* within a shipping zone. Real Time Carrier Connections are also supported by this endpoint. 
@@ -1232,7 +1232,7 @@ paths:
                     handling_fees:
                       fixed_surcharge: "0"
                     is_fallback: false
-      operationId: createAShippingMethod
+      operationId: createShippingMethod
     parameters:
       - $ref: '#/components/parameters/Accept'
       - name: zone_id
@@ -1475,7 +1475,7 @@ paths:
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-      operationId: getAShippingMethod
+      operationId: getShippingMethod
     put:
       description: |-
         Updates a *Shipping Method* in a zone. Real Time Carrier Connections are also supported by this endpoint. 
@@ -1687,7 +1687,7 @@ paths:
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-      operationId: updateAShippingMethod
+      operationId: updateShippingMethod
     delete:
       description: Deletes an *Shipping Method*. Real Time Carrier Connections can also be deleted.
       summary: Delete a Shipping Method
@@ -1702,7 +1702,7 @@ paths:
         AllowDynamicQueryParameters: false
         AllowDynamicFormParameters: false
         IsMultiContentStreaming: false
-      operationId: deleteAShippingMethod
+      operationId: deleteShippingMethod
     parameters:
       - $ref: '#/components/parameters/Accept'
       - name: zone_id
@@ -1761,7 +1761,7 @@ paths:
           content:
             application/json:
               schema: {}
-      operationId: updateACarrierConnection
+      operationId: updateCarrierConnection
     post:
       description: |-
         Creates a *Carrier Connection*. 
@@ -1963,7 +1963,7 @@ paths:
         | auth_key | string | Zoom2U authorization key. |
         | test_mode | boolean | Whether or not to use Zoom2U test-mode settings. Acceptable values are `true` or `false`. |
       summary: Create a Carrier Connection
-      operationId: createACarrierConnection
+      operationId: createCarrierConnection
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:

--- a/reference/shipping.v3.yml
+++ b/reference/shipping.v3.yml
@@ -96,7 +96,7 @@ paths:
             items:
               type: integer
     put:
-      operationId: putCustomsInformation
+      operationId: updateCustomsInformation
       parameters:
         - $ref: '#/components/parameters/ContentType'
       responses:

--- a/reference/sites.v3.yml
+++ b/reference/sites.v3.yml
@@ -138,7 +138,7 @@ paths:
       - $ref: '#/components/parameters/Accept'
     post:
       summary: Create a Site
-      operationId: post-site
+      operationId: createSite
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -209,7 +209,7 @@ paths:
       description: 'Get a site with site ID `{site_id}`.'
     put:
       summary: Update a Site
-      operationId: putSite
+      operationId: updateSite
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -253,7 +253,7 @@ paths:
           type: integer
     get:
       summary: Get a Site’s Routes
-      operationId: index-site-routes
+      operationId: getSiteRoutes
       parameters:
         - name: type
           in: query
@@ -308,7 +308,7 @@ paths:
       description: Get a site’s routes.
     post:
       summary: Create a Site Route
-      operationId: post-site-route
+      operationId: createSiteRoute
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -407,7 +407,7 @@ paths:
   '/sites/{site_id}/routes/{route_id}':
     get:
       summary: Get a Site Route
-      operationId: get-site-route
+      operationId: getSiteRoute
       responses:
         '200':
           description: ''
@@ -434,7 +434,7 @@ paths:
       description: Get a site’s route.
     put:
       summary: Update a Site Route
-      operationId: put-site-route
+      operationId: updateSiteRoute
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -457,7 +457,7 @@ paths:
         Update a site’s route.
     delete:
       summary: Delete a Site Route
-      operationId: delete-route
+      operationId: deleteSiteRoute
       responses:
         '204':
           description: ''
@@ -489,7 +489,7 @@ paths:
       description: Obtain information about a site’s SSL/TLS certificate.
       tags:
         - Site Certificate
-      operationId: getSitesIdCertificate
+      operationId: getSiteCertificate
       responses:
         '200':
           description: OK
@@ -500,7 +500,7 @@ paths:
               examples: {}
     put:
       summary: Upsert a Site’s SSL/TLS Certificate Information
-      operationId: putSiteIdCertificate
+      operationId: upsertSiteCertificate
       parameters:
         - $ref: '#/components/parameters/ContentType'
       tags:
@@ -543,7 +543,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetCertificatesResponse'
-      operationId: get-sites-certificates
+      operationId: getSitesCertificates
       description: Return all SSL certificates connected to domains within a store.
       parameters:
         - schema:

--- a/reference/store_content.v2.yml
+++ b/reference/store_content.v2.yml
@@ -37,7 +37,7 @@ paths:
         - Blog Tags
       summary: Get All Blog Tags
       description: Returns a list of *Blog Tags*.
-      operationId: getAllBlogTags
+      operationId: getBlogTags
       responses:
         '200':
           description: ''
@@ -55,7 +55,7 @@ paths:
         - Blog Posts
       summary: Get All Blog Posts
       description: 'Returns all *Blog Posts*. Default sorting is by published_date, beginning with the most recent post.'
-      operationId: getAllBlogPosts
+      operationId: getBlogPosts
       parameters:
         - name: is_published
           in: query
@@ -180,7 +180,7 @@ paths:
         * When including `published_date` in a request, supply it as a flat date string (not an object) in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a>. The&#160;example request below includes a `published_date` in RFC 2822 format.
         * Blog posts default to draft status. To publish blog posts to the storefront, set the `is_published` property to `true`.
         * If a custom URL is not provided, the post’s URL will be generated based on the value of `title`.
-      operationId: createABlogPosts
+      operationId: createBlogPosts
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -228,7 +228,7 @@ paths:
         - Blog Posts
       summary: Delete Blog Posts
       description: Deletes a page of `Blog Posts`.
-      operationId: deleteAllBlogPosts
+      operationId: deleteBlogPosts
       parameters:
         - name: page
           in: query
@@ -266,7 +266,7 @@ paths:
         - Blog Posts
       summary: Get a Blog Post
       description: Returns a single *Blog Post*.
-      operationId: getABlogPost
+      operationId: getBlogPost
       responses:
         '200':
           description: ''
@@ -307,7 +307,7 @@ paths:
         * When including `published_date` in a request, supply it as a flat date string (not an object) in valid <a href="http://tools.ietf.org/html/rfc2822#section-3.3" target="_blank">RFC 2822</a>. The&#160;example request below includes a `published_date` in RFC 2822 format.
 
         * Blog posts default to draft status. To publish blog posts to the storefront, set the `is_published` property to `true`.
-      operationId: updateABlogPost
+      operationId: updateBlogPost
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -356,7 +356,7 @@ paths:
         - Blog Posts
       summary: Delete a Blog Post
       description: Deletes a *Blog Post*.
-      operationId: deleteABlogPost
+      operationId: deleteBlogPost
       responses:
         '204':
           description: ''
@@ -369,7 +369,7 @@ paths:
         - Blog Posts
       summary: Get A Count of All Blog Posts
       description: Returns a count of all *Blog Posts*.
-      operationId: getACountOfAllBlogPosts
+      operationId: getBlogPostsCount
       responses:
         '200':
           description: ''
@@ -394,7 +394,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To get one or more pages, use Pages V3ʼs [Get pages](/docs/rest-content/pages#get-pages) endpoint. To get a single page, use Pages V3ʼs [Get a page](/docs/rest-content/pages#get-a-page) endpoint.
-      operationId: getAllPages
+      operationId: getPages
       parameters:
         - name: page
           in: query
@@ -467,7 +467,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To create one or more pages, use Pages V3ʼs [Create pages](/docs/rest-content/pages#create-pages) endpoint. 
-      operationId: createAPage
+      operationId: createPage
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -557,7 +557,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To get a single page, use Pages V3ʼs [Get a page](/docs/rest-content/pages#get-a-page) endpoint.
-      operationId: getAPage
+      operationId: getPage
       responses:
         '200':
           description: ''
@@ -600,7 +600,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To update multiple pages, use Pages V3ʼs [Update pages](/docs/rest-content/pages#update-pages) endpoint. To update a single page, use Pages V3ʼs [Update a page](/docs/rest-content/pages#update-a-page) endpoint.
-      operationId: updateAPage
+      operationId: updatePage
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -655,7 +655,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To delete multiple pages, use Pages V3ʼs [Delete pages](/docs/rest-content/pages#delete-pages) endpoint. To delete a single page, use Pages V3ʼs [Delete a page](/docs/rest-content/pages#delete-a-page) endpoint. 
-      operationId: deleteAPage
+      operationId: deletePage
       responses:
         '204':
           description: ''
@@ -675,7 +675,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To get redirect URLs, use Redirects V3ʼs [Get redirects](/docs/rest-management/redirects#get-redirects) endpoint.
-      operationId: getAListofRedirects
+      operationId: getRedirects
       parameters:
         - name: page
           in: query
@@ -721,7 +721,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To upsert new redirect data, use Redirects V3ʼs [Upsert redirects](/docs/rest-management/redirects#upsert-redirects) endpoint.
-      operationId: createARedirect
+      operationId: createRedirect
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -758,7 +758,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To delete redirect URLs, use Redirects V3ʼs [Delete redirects](/docs/rest-management/redirects#delete-redirects) endpoint.
-      operationId: deleteAllRedirects
+      operationId: deleteRedirects
       responses:
         '204':
           description: ''
@@ -786,7 +786,7 @@ paths:
         > **Deprecated** 
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To get a redirect URL, use Redirects V3ʼs [Get redirects](/docs/rest-management/redirects#get-redirects) endpoint.
-      operationId: getARedirectURL
+      operationId: getRedirect
       responses:
         '200':
           description: ''
@@ -820,7 +820,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To update redirect data, use Redirects V3ʼs [Upsert redirects](/docs/rest-management/redirects#upsert-redirects) endpoint.
-      operationId: updateARedirectURL
+      operationId: updateRedirect
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -891,7 +891,7 @@ paths:
         > **Deprecated** 
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To delete a redirect URL, use Redirects V3ʼs [Delete redirects](/docs/rest-management/redirects#delete-redirects) endpoint.
-      operationId: deleteARedirect
+      operationId: deleteRedirect
       responses:
         '204':
           description: ''
@@ -911,7 +911,7 @@ paths:
         > **Deprecated**
         > * This API operation is deprecated. Avoid using this API operation if possible. It will be removed in a future version.
         > * To get a count of redirects, use the `meta` object data returned with the Redirects V3ʼs [Get redirects](/docs/rest-management/redirects#get-redirects) endpoint.
-      operationId: getACountOfRedirects
+      operationId: getRedirectsCount
       responses:
         '200':
           description: ''

--- a/reference/store_information.v2.yml
+++ b/reference/store_information.v2.yml
@@ -13,6 +13,7 @@ paths:
     get:
       description: Returns metadata about a store.
       summary: Get Store Information
+      operationId: getStoreInformation
       tags:
         - Store Information
       parameters:
@@ -140,6 +141,7 @@ paths:
     get:
       description: Returns the system timestamp at the time of the request. The time resource is useful for validating API authentication details and testing client connections.
       summary: Get System Timestamp
+      operationId: getSystemTimestamp
       parameters:
         - name: Accept
           in: header

--- a/reference/store_logs.v3.yml
+++ b/reference/store_logs.v3.yml
@@ -22,7 +22,7 @@ paths:
       description: 'Get system logs '
       tags:
         - System Logs
-      operationId: get-sites
+      operationId: getStoreSystemLogs
       responses:
         '200':
           description: The request completed successfully.

--- a/reference/subscribers.v3.yml
+++ b/reference/subscribers.v3.yml
@@ -262,7 +262,7 @@ paths:
       - Subscribers
       summary: Get a Subscriber
       description: Returns a *Subscriber*.
-      operationId: getSubscriberById
+      operationId: getSubscriber
       parameters:
       - name: subscriber_id
         in: path
@@ -423,7 +423,7 @@ paths:
       - Subscribers
       summary: Delete a Subscriber
       description: Deletes a *Subscriber*.
-      operationId: deleteSubscriberById
+      operationId: deleteSubscriber
       parameters:
       - name: subscriber_id
         in: path

--- a/reference/subscriptions.sf.yml
+++ b/reference/subscriptions.sf.yml
@@ -33,7 +33,7 @@ paths:
       tags:
         - Subscription
       summary: Create a Subscription
-      operationId: createASubscription
+      operationId: createSubscription
       description: |-
         Creates or updates an email subscription.
 

--- a/reference/tax.v3.yml
+++ b/reference/tax.v3.yml
@@ -28,7 +28,7 @@ paths:
 
         > #### Note
         > * Requires **read** permissions on the **Information and Settings** scope.
-      operationId: provider-connection-get
+      operationId: getTaxProviderConnection
       responses:
         '200':
           description: OK
@@ -54,7 +54,7 @@ paths:
         > #### Note
         > * This operation will be logged in [Store Logs](https://support.bigcommerce.com/s/article/Using-Store-Logs) under **Staff Actions**.
         > * Requires **write** permissions on the **Information and Settings** [scope](/api-docs/getting-started/api-accounts#oauth-scopes).
-      operationId: provider-connection-delete
+      operationId: deleteTaxProviderConnection
       responses:
         '200':
           description: OK
@@ -104,7 +104,7 @@ paths:
       summary: Update a Connection
       parameters:
         - $ref: '#/components/parameters/ContentType'
-      operationId: provider-connection-put
+      operationId: updateTaxProviderConnection
       tags:
         - Tax Provider Connection
       requestBody:

--- a/reference/tax_classes.v2.yml
+++ b/reference/tax_classes.v2.yml
@@ -31,7 +31,7 @@ paths:
         Returns a list of all *Tax Classes* in a store.
 
         Default sorting is by tax-class id, from lowest to highest.
-      operationId: getAllTaxClasses
+      operationId: getTaxClasses
       parameters:
       - $ref: '#/components/parameters/Accept'
       - name: page
@@ -84,7 +84,7 @@ paths:
       - Taxes
       summary: Get a Tax Class
       description: Returns a single *Tax Class*.
-      operationId: getATaxClass
+      operationId: getTaxClass
       parameters:
         - $ref: '#/components/parameters/Accept'
         - name: id

--- a/reference/tax_properties.v3.yml
+++ b/reference/tax_properties.v3.yml
@@ -29,7 +29,7 @@ paths:
         - Tax Properties
       summary: Get Tax Properties
       description: Retrieve all tax properties defined in this store.
-      operationId: get-tax-properties
+      operationId: getTaxProperties
       parameters:
         - $ref: "#/components/parameters/idin"
       responses:
@@ -54,7 +54,7 @@ paths:
       summary: Update Tax Properties
       description: Update one or more tax properties. Only fields specified will be
         adjusted.
-      operationId: update-tax-properties
+      operationId: updateTaxProperties
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -87,7 +87,7 @@ paths:
       summary: Create Tax Properties
       description: Create one or more tax properties. A **code** and a **display name**
         must be included when creating tax properties.
-      operationId: create-tax-properties
+      operationId: createTaxProperties
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -120,7 +120,7 @@ paths:
       summary: Delete Tax Properties
       description: Delete one or multiple tax properties. A tax property must have zero
         usages within product tax properties before you can delete it.
-      operationId: delete-tax-properties
+      operationId: deleteTaxProperties
       parameters:
         - $ref: "#/components/parameters/idin_required"
       responses:
@@ -139,7 +139,7 @@ paths:
       summary: Get Product Tax Properties
       description: Retrieve the tax properties that are associated with one or more
         products.
-      operationId: get-product-tax-properties
+      operationId: getProductsTaxProperties
       parameters:
         - $ref: "#/components/parameters/product_idin"
       responses:
@@ -165,7 +165,7 @@ paths:
       description: Update the tax properties associated with one or more products. This
         operation will be additive to any tax property values already associated
         with the product, overwriting any existing tax property values.
-      operationId: update-product-tax-properties
+      operationId: updateProductTaxProperties
       parameters:
         - $ref: '#/components/parameters/ContentType'
       requestBody:
@@ -204,7 +204,7 @@ paths:
         - Product Tax Properties
       summary: Delete Product Tax Properties
       description: Delete tax properties that are associated with one or more products.
-      operationId: delete-product-tax-properties
+      operationId: deleteProductTaxProperties
       parameters:
         - $ref: "#/components/parameters/product_idin"
       responses:

--- a/reference/tax_provider.yml
+++ b/reference/tax_provider.yml
@@ -48,7 +48,7 @@ paths:
         - Order refund.
         - Edit order.
         - Test connection feature in Tax Settings.
-      operationId: estimate
+      operationId: estimateTaxes
       parameters:
         - $ref: '#/components/parameters/header-storehash'
       requestBody:
@@ -316,7 +316,7 @@ paths:
         > - For supporting tax providers, the server URL contains the tax provider's profile field; for example, `your_profile.example.com`.
         > - The Try it feature is not currently supported for this endpoint.
 
-      operationId: void
+      operationId: voidTaxQuote
       parameters:
         - name: id
           in: query
@@ -346,7 +346,7 @@ paths:
         > - For supporting tax providers, the server URL contains the tax provider's profile field; for example, `your_profile.example.com`.
         > - The Try it feature is not currently supported for this endpoint.
 
-      operationId: commit
+      operationId: commitTaxQuote
       parameters:
         - $ref: '#/components/parameters/header-storehash'
       requestBody:
@@ -851,7 +851,7 @@ paths:
         > - For supporting tax providers, the server URL contains the tax provider's profile field; for example, `your_profile.example.com`.
         > - The Try it feature is not currently supported for this endpoint.
         
-      operationId: adjust
+      operationId: adjustTaxQuote
       tags:
         - Tax Provider
       parameters:

--- a/reference/tax_rates_zones.v3.yml
+++ b/reference/tax_rates_zones.v3.yml
@@ -30,7 +30,7 @@ paths:
         - Tax Zones
       summary: Get Tax Zones
       description: 'Retrieve a selection of tax zones when you provide a list of tax zone IDs. Otherwise, retrieve all tax zones defined on the store.'
-      operationId: get-tax-zones
+      operationId: getTaxZones
       responses:
         '200':
           description: OK
@@ -78,7 +78,7 @@ paths:
         - Tax Zones
       summary: Update Tax Zones
       description: Update one or more tax zones. Only the tax zone `id` field is required. Fields unspecified by the request will retain their current state.
-      operationId: update-tax-zones
+      operationId: updateTaxZones
       requestBody:
         $ref: '#/components/requestBodies/Tax_ZoneArray'
       responses:
@@ -128,7 +128,7 @@ paths:
         > #### Note
         > You cannot create a default tax zone.
         
-      operationId: create-tax-zones
+      operationId: createTaxZones
       requestBody:
         $ref: '#/components/requestBodies/Tax_ZoneArrayPOST'
       responses:
@@ -183,7 +183,7 @@ paths:
         > #### Note
         > You must specify which zone(s) to delete using the `id:in` query parameter.
 
-      operationId: delete-tax-zones
+      operationId: deleteTaxZones
       responses:
         '204':
           description: No Content
@@ -196,7 +196,7 @@ paths:
         - Tax Rates
       summary: Get Tax Rates
       description: Retrieve a list of tax rates.
-      operationId: get-tax-rates
+      operationId: getTaxRates
       parameters:
         - $ref: '#/components/parameters/rateIdIn'
         - $ref: '#/components/parameters/taxZoneIdIn'
@@ -222,7 +222,7 @@ paths:
         - Tax Rates
       summary: Update Tax Rates
       description: Update one or more tax rates. Only the tax rate `id` field is required. Fields unspecified by the request will retain their current state.
-      operationId: update-tax-rates
+      operationId: updateTaxRates
       requestBody:
         $ref: '#/components/requestBodies/Tax_RateArray'
       responses:
@@ -259,7 +259,7 @@ paths:
         - Tax Rates
       summary: Create Tax Rates
       description: Create one or more tax rates. Tax rates must be associated with a `tax_zone_id`.
-      operationId: create-tax-rates
+      operationId: createTaxRates
       requestBody:
         $ref: '#/components/requestBodies/Tax_RateArrayPOST'
       responses:
@@ -301,7 +301,7 @@ paths:
         > #### Note
         > You must specify which rate(s) to delete using the `id:in` query parameter.
 
-      operationId: delete-tax-rates
+      operationId: deleteTaxRates
       responses:
         '204':
           description: No Content

--- a/reference/tax_settings.v3.yml
+++ b/reference/tax_settings.v3.yml
@@ -26,7 +26,7 @@ paths:
         - Tax Settings
       summary: Get Tax Settings
       description: Retrieves global-level tax settings.
-      operationId: get-tax-settings
+      operationId: getTaxSettings
       responses:
         '200':
           description: OK
@@ -44,7 +44,7 @@ paths:
         - Tax Settings
       summary: Update Tax Settings
       description: Updates global-level tax settings.
-      operationId: set-tax-settings
+      operationId: updateTaxSettings
       parameters:
       - $ref: '#/components/parameters/ContentType'
       requestBody:

--- a/reference/themes.v3.yml
+++ b/reference/themes.v3.yml
@@ -106,7 +106,7 @@ paths:
     post:
       tags:
         - Themes
-      operationId: uploadTheme
+      operationId: uploadStoreTheme
       summary: Upload a Theme
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -289,7 +289,7 @@ paths:
     post:
       tags:
         - Theme Actions
-      operationId: downloadTheme
+      operationId: downloadStoreTheme
       summary: Download a Theme
       parameters:
         - $ref: '#/components/parameters/ContentType'
@@ -412,7 +412,7 @@ paths:
     get:
       tags:
         - Theme Jobs
-      operationId: getJob
+      operationId: getStoreThemeJob
       summary: Get a Theme Job
       responses:
         '200':
@@ -629,7 +629,7 @@ paths:
                         - custom-page-1.html
                         - holiday-page.html
                     meta: {}
-      operationId: get-themes-theme_uuid-custom-templates
+      operationId: getThemeCustomTemplates
       description: Enumerate available custom templates for in the theme files in a specific theme version for each supported entity type.
 components:
   parameters:

--- a/reference/webhooks.v3.yml
+++ b/reference/webhooks.v3.yml
@@ -102,7 +102,7 @@ paths:
         Returns a list of all webhooks on a store associated to the `client_id` used to authenticate the request.
 
         *Note: BigCommerce determines the `client_id` from the `access_token`.*
-      operationId: getAllWebhooks
+      operationId: getWebhooks
       tags:
         - Manage Webhooks (Bulk)
       parameters:
@@ -140,7 +140,7 @@ paths:
           $ref: '#/components/responses/webhook_Resp'
       summary: Update a Webhook
       description: Updates a webhook. Custom headers can be added.
-      operationId: updateAWebhook
+      operationId: updateWebhook
       parameters:
         - $ref: '#/components/parameters/Accept'
         - $ref: '#/components/parameters/Content-Type'
@@ -165,7 +165,7 @@ paths:
           $ref: '#/components/responses/webhook_Resp'
       summary: Delete a Webhook
       description: 'Deletes a webhook. Only one webhook at a time can be deleted. When a webhook is deleted, it is returned in the response as a 200 OK.'
-      operationId: deleteAWebhook
+      operationId: deleteWebhook
       tags:
         - Manage Webhooks (Single)
       parameters:
@@ -274,7 +274,7 @@ paths:
       tags:
         - Webhooks Admin
     put:
-      operationId: putHooksAdmin
+      operationId: updateHooksAdmin
       summary: Upsert Email Notifications
       description: |
         Update email addresses that are sent notification emails when any domain associated with the API account is denylisted or when a webhook is deactivated. Supports `upsert` functionality in the case that no email address exists yet.

--- a/reference/wishlists.v3.yml
+++ b/reference/wishlists.v3.yml
@@ -32,7 +32,7 @@ paths:
         - Wishlists
       summary: Get All Wishlists
       description: Returns a list of wishlists. Optional filter parameters can be passed in.
-      operationId: WishlistsGet
+      operationId: getWishlists
       parameters:
         - name: customer_id
           in: query
@@ -162,7 +162,7 @@ paths:
         **Required Fields**
         * name
         * customer_id
-      operationId: WishlistsPost
+      operationId: createWishlist
       parameters:
         - $ref: '#/components/parameters/Accept'
         - $ref: '#/components/parameters/ContentType'
@@ -248,7 +248,7 @@ paths:
         - Wishlists Items
       summary: Delete Wishlist Item
       description: Deletes a wishlist item.
-      operationId: WishlistsItemsByIdDelete
+      operationId: deleteWishlistItem
       parameters:
         - $ref: '#/components/parameters/WishlistID'
         - $ref: '#/components/parameters/Accept'
@@ -339,7 +339,7 @@ paths:
         - Wishlists
       summary: Get a Wishlist
       description: Returns a single wishlist.
-      operationId: WishlistsByIdGet
+      operationId: getWishlist
       parameters:
         - $ref: '#/components/parameters/WishlistID'
         - $ref: '#/components/parameters/Accept'
@@ -426,7 +426,7 @@ paths:
         Updates a wishlist.
 
         Use this endpoint to update existing wishlist items, change the wishlist's name and whether the wishlist is available publicly. To add or delete a wishlist item, see [Wishlist Items](/docs/rest-management/wishlists/wishlists-items).
-      operationId: WishlistsByIdPut
+      operationId: updateWishlist
       parameters:
         - $ref: '#/components/parameters/WishlistID'
         - $ref: '#/components/parameters/Accept'
@@ -512,7 +512,7 @@ paths:
         - Wishlists
       summary: Delete a Wishlist
       description: Deletes a wishlist.
-      operationId: WishlistsByIdDelete
+      operationId: deleteWishlist
       parameters:
         - $ref: '#/components/parameters/WishlistID'
         - $ref: '#/components/parameters/Accept'
@@ -556,7 +556,7 @@ paths:
         - Wishlists Items
       summary: Add Wishlist Item
       description: Adds a wishlist item. More than one item can be added at a time.
-      operationId: WishlistsItemsByIdPost
+      operationId: addWishlistItem
       parameters:
         - $ref: '#/components/parameters/WishlistID'
         - $ref: '#/components/parameters/Accept'


### PR DESCRIPTION
# [DEVDOCS-]

As per OpenAPI specification guidance for operationID field, follow programmatic
conventions for operationId field. To me that means as if I were defining a method
or function name.

<img width="701" alt="Screenshot 2023-09-17 at 20 44 14" src="https://github.com/bigcommerce/api-specs/assets/553566/d208392e-d8e0-4d3a-87ca-48d355a7ddc2">

This field is not used in the API docs as far as I can tell. There were
many different naming conventions across APIs. I've aligned to be camel case.

This help facilitate API SDK generation as all endpoints can have a function named
based on the operation ID and it have sufficient context to be unique amongst all APIs

## What changed?
Provide a bulleted list in the present tense
* Make operation IDs consistent and follow programmatic conventions
