### PR TITLE
docs(checkout): CHECKOUT-7716 Include the gift_wrapping structure and a sample in the v3/cart response

### DIFF
--- a/reference/carts.v3.yml
+++ b/reference/carts.v3.yml
@@ -2924,6 +2924,20 @@ components:
                     type: number
                     description: The product option value identifier in number format.
                     example: 128
+            gift_wrapping:
+              description: The gift wrapping details for this item.
+              type: object
+              properties:
+                name:
+                  type: string
+                  example: Gift Wrap 1
+                message:
+                  type: string
+                  example: Happy Birthday!
+                amount:
+                  type: number
+                  format: float
+                  example: 1.99
           required:
             - variant_id
             - product_id


### PR DESCRIPTION
# [CHECKOUT-7716](https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7716)
## What changed?
Provide a bulleted list in the present tense
* Include the gift_wrapping structure and a sample in the v3/cart response
![image](https://github.com/bigcommerce/api-specs/assets/84553389/240c9b84-568e-44d7-9e7c-54d2e8b1f1aa)


ping @bigcommerce/dev-docs @bigcommerce/team-checkout 

[CHECKOUT-7716]: https://bigcommercecloud.atlassian.net/browse/CHECKOUT-7716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ