### PR TITLE
(external): [update] Abandoned Carts, remove duplicate channel_id param

### DIFF
--- a/reference/abandoned_carts.v3.yml
+++ b/reference/abandoned_carts.v3.yml
@@ -87,13 +87,6 @@ paths:
       operationId: getChannelAbandonedCartSettings
       tags:
         - Abandoned Carts Settings
-      parameters:
-        - name: channel_id
-          description: The channel ID of the settings overrides
-          in: path
-          required: true
-          schema:
-            type: integer
       responses:
         '200':
           description: OK
@@ -120,12 +113,6 @@ paths:
       tags:
         - Abandoned Carts Settings
       parameters:
-        - name: channel_id
-          description: The channel ID of the settings overrides
-          in: path
-          required: true
-          schema:
-            type: integer
         - $ref: '#/components/parameters/ContentType'
       requestBody:
         required: true
@@ -154,13 +141,13 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
       security: []
     parameters:
-      
       - $ref: '#/components/parameters/Accept'
-      - schema:
-          type: string
-        name: channel_id
+      - name: channel_id
+        description: The channel ID of the settings overrides
         in: path
         required: true
+        schema:
+          type: integer
   '/abandoned-carts/{token}':
     get:
       responses:


### PR DESCRIPTION
# [DEVDOCS-]

The `channel_id` param is defined on a method level as well as an endpoint level. Remove it from the method level

## What changed?
Provide a bulleted list in the present tense
* remove duplicate `channel_id` on abandoned cart settings endpoint.  

## Anything else?
Add related PRs, salient notes, ticket numbers, etc.

ping {names}
