### PR TITLE
(no ticket): [revise] query param include should accept comma separated list of values

### DIFF
--- a/reference/catalog/products_catalog.v3.yml
+++ b/reference/catalog/products_catalog.v3.yml
@@ -302,17 +302,20 @@ paths:
               * modifiers
               * options
               * videos
+          explode: false
           schema:
-            type: string
-            enum:
-              - variants
-              - images
-              - custom_fields
-              - bulk_pricing_rules
-              - primary_image
-              - modifiers
-              - options
-              - videos
+            type: array
+            items:
+              type: string
+              enum:
+                - variants
+                - images
+                - custom_fields
+                - bulk_pricing_rules
+                - primary_image
+                - modifiers
+                - options
+                - videos
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'
@@ -1348,17 +1351,20 @@ paths:
         - name: include
           in: query
           description: 'Sub-resources to include on a product, in a comma-separated list. If `options` or `modifiers` is used, results are limited to 10 per page.'
+          explode: false
           schema:
-            type: string
-            enum:
-              - variants
-              - images
-              - custom_fields
-              - bulk_pricing_rules
-              - primary_image
-              - modifiers
-              - options
-              - videos
+            type: array
+            items:
+              type: string
+              enum: 
+                - variants
+                - images
+                - custom_fields
+                - bulk_pricing_rules
+                - primary_image
+                - modifiers
+                - options
+                - videos
         - name: include_fields
           in: query
           description: 'Fields to include, in a comma-separated list. The ID and the specified fields will be returned.'

--- a/reference/customers.v3.yml
+++ b/reference/customers.v3.yml
@@ -171,13 +171,18 @@ paths:
              * `segment_ids`- segments the customer belongs to (Beta)
 
              `include=addresses,storecredit,attributes,formfields,shopper_profile_id,segment_ids`
+          explode: false
           schema:
-            type: string
-            enum:
-              - addresses
-              - storecredit
-              - attributes
-              - formfields
+            type: array
+            items:
+              type: string
+              enum:
+                - addresses
+                - storecredit
+                - attributes
+                - formfields
+                - shopper_profile_id
+                - segment_ids
         - in: query
           name: sort
           description: 'Sort items by date_created, date_modified, or last_name:* `date_created:asc` - date created, ascending* `date_created:desc` - date created, descending* `last_name:asc` - last name, ascending* `last_name:desc` - last name, descending * `date_modified:asc` - date modified, ascending* `date_modified:desc`- date modified, descending  Example: `sort=last_name:asc`'

--- a/reference/orders.sf.yml
+++ b/reference/orders.sf.yml
@@ -47,16 +47,19 @@ paths:
         - name: include
           in: query
           description: Sub-resources to include in an Order, in a comma-separated list. The ID and the specified fields will be returned.
+          explode: false
           schema:
-            type: string
-            enum:
-              - lineItems
-              - billingAddress
-              - coupons
-              - currency
-              - taxes
-              - payments
-              - consignments
+            type: array
+            items:
+              type: string
+              enum:
+                - lineItems
+                - billingAddress
+                - coupons
+                - currency
+                - taxes
+                - payments
+                - consignments
       responses:
         '200':
           description: ''

--- a/reference/price_lists.v3.yml
+++ b/reference/price_lists.v3.yml
@@ -849,11 +849,14 @@ paths:
           in: query
           description: |
             Sub-resources to include on a price record, in a comma-separated list. Valid expansions currently include `bulk_pricing_tiers` and `sku`. Other values will be ignored.
+          explode: false
           schema:
-            type: string
-            enum:
-              - bulk_pricing_tiers
-              - sku
+            type: array
+            items:
+              type: string
+              enum:
+                - bulk_pricing_tiers
+                - sku
         - name: price
           in: query
           description: |
@@ -1934,11 +1937,14 @@ paths:
           description: |
             Sub-resources to include on a price record, in a comma-separated list. Valid expansions currently include `bulk_pricing_tiers` and `sku`. Other values will be ignored.
             Sub-resources to include on a price record, in a comma-separated list. Valid expansions currently include `bulk_pricing_tiers` and `sku`. Other values will be ignored.
+          explode: false
           schema:
-            type: string
-            enum:
-              - bulk_pricing_tiers
-              - sku
+            type: array
+            items:
+              type: string
+              enum:
+                - bulk_pricing_tiers
+                - sku
       responses:
         '200':
           description: ''


### PR DESCRIPTION
## What changed?

_For context, this PR originated from: https://github.com/matthewvolk/bigrequest/issues/84 as a solution for inconsistent Typescript type definitions being generated from our OpenAPI spec files. I haven't checked if these changes introduce any unintended side effects to other ways our spec files are consumed!_

- Refactors the schema definition of the `include` query parameter across various API endpoints to indicate that `include` accepts a comma-separated list of enum values, rather than one-of an enum value. 
- A schema with `type: string` and `enum: [value1,value2]` resolves to: `?include=[value1|value2]` (_either_ `value1` _or_ `value2`) ([source: swagger.io](https://swagger.io/docs/specification/data-models/enums/))
- If we instead describe the schema as a `type: array`, where the `items` in the array are of `type: string` and can be one or more of `items.enum: [value1,value2]` the schema now resolves to: `?include=[value1[,value2]`
- `explode: false` is also added to indicate that query parameter values can be expressed in the format: `/users?id=3,4,5` as opposed to `/users?id=3&id=4&id=5` ([source: swagger.io)](https://swagger.io/docs/specification/serialization/#query))

## Anything else?

There are a number of locations in other files that we may want to apply these changes to, but I haven't confirmed that each location accepts a comma separated list of strings. Here is a list: https://github.com/search?q=repo%3Abigcommerce%2Fapi-specs%20%22-%20name%3A%20include%22&type=code